### PR TITLE
User/bbowman/add az cli option

### DIFF
--- a/src/PackageUploader.ClientApi/Client/Ingestion/TokenProvider/AccessTokenProviderExtensions.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/TokenProvider/AccessTokenProviderExtensions.cs
@@ -19,6 +19,9 @@ internal static class AccessTokenProviderExtensions
     public static IServiceCollection AddDefaultAzureCredentialAccessTokenProvider(this IServiceCollection services, IConfiguration config) =>
         services.AddAccessTokenProvider<DefaultAzureCredentialAccessTokenProvider>(config);
 
+    public static IServiceCollection AddAzureCliAccessTokenProvider(this IServiceCollection services, IConfiguration config) =>
+        services.AddAccessTokenProvider<AzureCliAccessTokenProvider>(config);
+
     public static IServiceCollection AddInteractiveBrowserCredentialAccessTokenProvider(this IServiceCollection services, IConfiguration config) =>
         services.AddAccessTokenProvider<InteractiveBrowserCredentialAccessTokenProvider>(config);
 

--- a/src/PackageUploader.ClientApi/Client/Ingestion/TokenProvider/AzureCliAccessTokenProvider.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/TokenProvider/AzureCliAccessTokenProvider.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Azure.Identity;
+using PackageUploader.ClientApi.Client.Ingestion.TokenProvider.Config;
+using PackageUploader.ClientApi.Client.Ingestion.TokenProvider.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PackageUploader.ClientApi.Client.Ingestion.TokenProvider;
+
+public class AzureCliAccessTokenProvider : IAccessTokenProvider
+{
+    private readonly AccessTokenProviderConfig _config;
+    private readonly ILogger<AzureCliAccessTokenProvider> _logger;
+
+    public AzureCliAccessTokenProvider(IOptions<AccessTokenProviderConfig> config, ILogger<AzureCliAccessTokenProvider> logger)
+    {
+        _config = config.Value;
+        _logger = logger;
+    }
+
+    public async Task<IngestionAccessToken> GetTokenAsync(CancellationToken ct)
+    {
+        var azureCredentialOptions = new DefaultAzureCredentialOptions
+        {
+            AuthorityHost = new Uri(_config.AadAuthorityBaseUrl),
+            ExcludeAzurePowerShellCredential = true,
+            ExcludeEnvironmentCredential = true,
+            ExcludeInteractiveBrowserCredential = true,
+            ExcludeSharedTokenCacheCredential = true,
+            ExcludeVisualStudioCodeCredential = true,
+            ExcludeVisualStudioCredential = true,
+            ExcludeManagedIdentityCredential = true,
+            // Only use Azure CLI credential. There are certain cases where other cred types take precendence over Azure CLI and therefore
+            // explicity exclude all other credential types.
+            ExcludeAzureDeveloperCliCredential = false,
+            ExcludeAzureCliCredential = false,
+        };
+        var azureCredential = new DefaultAzureCredential(azureCredentialOptions);
+
+        _logger.LogDebug("Requesting authentication token");
+        var scopes = new[] { $"{_config.AadResourceForCaller}/.default" };
+        var requestContext = new TokenRequestContext(scopes);
+        var token = await azureCredential.GetTokenAsync(requestContext, ct).ConfigureAwait(false);
+
+        return new IngestionAccessToken
+        {
+            AccessToken = token.Token, 
+            ExpiresOn = token.ExpiresOn
+        };
+    }
+}

--- a/src/PackageUploader.ClientApi/Client/Ingestion/TokenProvider/AzureCliAccessTokenProvider.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/TokenProvider/AzureCliAccessTokenProvider.cs
@@ -26,22 +26,11 @@ public class AzureCliAccessTokenProvider : IAccessTokenProvider
 
     public async Task<IngestionAccessToken> GetTokenAsync(CancellationToken ct)
     {
-        var azureCredentialOptions = new DefaultAzureCredentialOptions
+        var azureCredentialOptions = new AzureCliCredentialOptions
         {
             AuthorityHost = new Uri(_config.AadAuthorityBaseUrl),
-            ExcludeAzurePowerShellCredential = true,
-            ExcludeEnvironmentCredential = true,
-            ExcludeInteractiveBrowserCredential = true,
-            ExcludeSharedTokenCacheCredential = true,
-            ExcludeVisualStudioCodeCredential = true,
-            ExcludeVisualStudioCredential = true,
-            ExcludeManagedIdentityCredential = true,
-            // Only use Azure CLI credential. There are certain cases where other cred types take precendence over Azure CLI and therefore
-            // explicity exclude all other credential types.
-            ExcludeAzureDeveloperCliCredential = false,
-            ExcludeAzureCliCredential = false,
         };
-        var azureCredential = new DefaultAzureCredential(azureCredentialOptions);
+        var azureCredential = new AzureCliCredential(azureCredentialOptions);
 
         _logger.LogDebug("Requesting authentication token");
         var scopes = new[] { $"{_config.AadResourceForCaller}/.default" };

--- a/src/PackageUploader.ClientApi/PackageUploader.ClientApi.csproj
+++ b/src/PackageUploader.ClientApi/PackageUploader.ClientApi.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
+    <PackageReference Include="Azure.Identity" Version="1.13.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.25" />

--- a/src/PackageUploader.ClientApi/PackageUploaderExtensions.cs
+++ b/src/PackageUploader.ClientApi/PackageUploaderExtensions.cs
@@ -17,6 +17,8 @@ public static class IngestionExtensions
         AppCert,
         Default, 
         Browser,
+
+        AzureCli,
     }
 
     public static IServiceCollection AddPackageUploaderService(this IServiceCollection services, IConfiguration config, 
@@ -38,6 +40,7 @@ public static class IngestionExtensions
             AuthenticationMethod.AppCert => services.AddAzureApplicationCertificateAccessTokenProvider(config),
             AuthenticationMethod.Browser => services.AddInteractiveBrowserCredentialAccessTokenProvider(config),
             AuthenticationMethod.Default => services.AddDefaultAzureCredentialAccessTokenProvider(config),
+            AuthenticationMethod.AzureCli => services.AddAzureCliAccessTokenProvider(config),
             _ => services.AddAzureApplicationSecretAccessTokenProvider(config),
         };
 }

--- a/src/PackageUploader.ClientApi/PackageUploaderExtensions.cs
+++ b/src/PackageUploader.ClientApi/PackageUploaderExtensions.cs
@@ -17,7 +17,6 @@ public static class IngestionExtensions
         AppCert,
         Default, 
         Browser,
-
         AzureCli,
     }
 


### PR DESCRIPTION
Add explicit auth option for AzureCli to better support Federated Credential scenarios / situations where AzCli is preferred but some other auth in the default cred fallbacks is being used instead