### PR TITLE
Issue43 duplicate package upload handling

### DIFF
--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Site_Reliability_PublicPackages" value="https://pkgs.dev.azure.com/microsoftstudiosrare/d5b8fd13-bbb5-4b8e-97a2-da9b5e60a7ec/_packaging/Site_Reliability_PublicPackages/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/PackageUploader.ClientApi/Client/Ingestion/Client/HttpRestClient.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/Client/HttpRestClient.cs
@@ -1,18 +1,23 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure;
 using Microsoft.Extensions.Logging;
 using PackageUploader.ClientApi.Client.Ingestion.Models.Internal;
 using PackageUploader.ClientApi.Client.Ingestion.Sanitizers;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Net.Mime;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -47,6 +52,42 @@ internal abstract class HttpRestClient : IHttpRestClient
 
             var result = await response.Content.ReadFromJsonAsync(jsonTypeInfo, ct).ConfigureAwait(false);
             return result;
+        }
+        catch (Exception ex)
+        {
+            LogException(ex);
+            throw;
+        }
+    }
+
+    public async Task<T> GetAsyncWithErrors<T>(string subUrl, JsonTypeInfo<T> jsonTypeInfo, IReadOnlySet<HttpStatusCode> allowableErrors, CancellationToken ct)
+    {
+        try
+        {
+            var request = CreateJsonRequestMessage(HttpMethod.Get, subUrl);
+
+            await LogRequestVerboseAsync(request, ct).ConfigureAwait(false);
+            using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+            await LogResponseVerboseAsync(response, ct).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
+            {
+                var result = await response.Content.ReadFromJsonAsync(jsonTypeInfo, ct).ConfigureAwait(false);
+                return result;
+            }
+            else if (allowableErrors.Contains(response.StatusCode))
+            {
+                var responseBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                responseBody = responseBody.Substring(responseBody.IndexOf("{"));
+                responseBody = Regex.Unescape(responseBody);
+                responseBody = responseBody.Substring(0, responseBody.LastIndexOf("}") + 1);
+                var result = JsonSerializer.Deserialize(responseBody, jsonTypeInfo);
+                return result;
+            }
+            else
+            {
+                response.EnsureSuccessStatusCode();
+                return default(T); // should not be reached
+            }
         }
         catch (Exception ex)
         {

--- a/src/PackageUploader.ClientApi/Client/Ingestion/Client/IHttpRestClient.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/Client/IHttpRestClient.cs
@@ -3,6 +3,7 @@
 
 using PackageUploader.ClientApi.Client.Ingestion.Models.Internal;
 using System.Collections.Generic;
+using System.Net;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ internal interface IHttpRestClient
 {
     Task<T> GetAsync<T>(string subUrl, JsonTypeInfo<T> jsonTypeInfo, CancellationToken ct);
     IAsyncEnumerable<T> GetAsyncEnumerable<T>(string subUrl, JsonTypeInfo<PagedCollection<T>> jsonTypeInfo, CancellationToken ct);
+    Task<T> GetAsyncWithErrors<T>(string subUrl, JsonTypeInfo<T> jsonTypeInfo, IReadOnlySet<HttpStatusCode> allowableErrors, CancellationToken ct);
     Task<T> PostAsync<T>(string subUrl, T body, JsonTypeInfo<T> jsonTypeInfo, CancellationToken ct);
     Task<TOut> PostAsync<TIn, TOut>(string subUrl, TIn body, JsonTypeInfo<TIn> jsonTInInfo, JsonTypeInfo<TOut> jsonTOutInfo, CancellationToken ct);
     Task<T> PutAsync<T>(string subUrl, T body, JsonTypeInfo<T> jsonTypeInfo, CancellationToken ct);

--- a/src/PackageUploader.ClientApi/Client/Ingestion/Client/IngestionJsonSerializerContext.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/Client/IngestionJsonSerializerContext.cs
@@ -21,5 +21,6 @@ namespace PackageUploader.ClientApi.Client.Ingestion.Client;
 [JsonSerializable(typeof(IngestionSubmissionCreationRequest))]
 [JsonSerializable(typeof(IngestionPackageCreationRequest))]
 [JsonSerializable(typeof(IngestionGamePackageAsset))]
+[JsonSerializable(typeof(IngestionRedirectPackage))]
 internal partial class IngestionJsonSerializerContext : JsonSerializerContext
 { }

--- a/src/PackageUploader.ClientApi/Client/Ingestion/IngestionHttpClient.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/IngestionHttpClient.cs
@@ -120,18 +120,11 @@ internal sealed class IngestionHttpClient : HttpRestClient, IIngestionHttpClient
         }
         catch(HttpRequestException e) when (e.StatusCode is HttpStatusCode.MovedPermanently)
         {
-            try
-            {
-                var redirectPackage = await GetAsyncWithErrors($"products/{productId}/packages/{packageId}", 
-                                                                IngestionJsonSerializerContext.Default.IngestionRedirectPackage, 
-                                                                new HashSet<HttpStatusCode>() {HttpStatusCode.MovedPermanently}, 
-                                                                ct).ConfigureAwait(false);
-                ingestionGamePackage = await GetAsync($"products/{productId}/packages/{redirectPackage.ToId}", IngestionJsonSerializerContext.Default.IngestionGamePackage, ct).ConfigureAwait(false);
-            }
-            catch(Exception ex)
-            {
-                throw new Exception("Failed to get package by id", ex);
-            }
+            var redirectPackage = await GetAsyncWithErrors($"products/{productId}/packages/{packageId}", 
+                                                            IngestionJsonSerializerContext.Default.IngestionRedirectPackage, 
+                                                            new HashSet<HttpStatusCode>() {HttpStatusCode.MovedPermanently}, 
+                                                            ct).ConfigureAwait(false);
+            ingestionGamePackage = await GetAsync($"products/{productId}/packages/{redirectPackage.ToId}", IngestionJsonSerializerContext.Default.IngestionGamePackage, ct).ConfigureAwait(false);
         }
 
         var gamePackage = ingestionGamePackage.Map();

--- a/src/PackageUploader.ClientApi/Client/Ingestion/Models/GamePackage.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/Models/GamePackage.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using PackageUploader.ClientApi.Client.Xfus.Models;
+using System.Numerics;
 
 namespace PackageUploader.ClientApi.Client.Ingestion.Models;
 
@@ -26,4 +27,5 @@ public sealed class GamePackage : GamePackageResource
     /// File size of the package
     /// </summary>
     public long? FileSize { get; set; }
+
 }

--- a/src/PackageUploader.ClientApi/Client/Ingestion/Models/Internal/IngestionRedirectPackage.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/Models/Internal/IngestionRedirectPackage.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PackageUploader.ClientApi.Client.Ingestion.Models.Internal
+{
+    internal class IngestionRedirectPackage : IngestionResource
+    {
+        /// <summary>
+        /// Name
+        /// </summary>
+        public string Name { get; set; }
+        /// <summary>
+        /// ToId
+        /// </summary>
+        public string ToId { get; set; }
+        /// <summary>
+        /// Uid
+        /// </summary>
+        public string Uid { get; set; }
+        /// <summary>
+        /// ProcessingState
+        /// </summary>
+        public string ProcessingState { get; set; }
+        /// <summary>
+        /// ValidationItems
+        /// </summary>
+        public IReadOnlyCollection<GameSubmissionValidationItem> ValidationItems { get; set; }
+    }
+}

--- a/src/PackageUploader.ClientApi/PackageUploaderService.cs
+++ b/src/PackageUploader.ClientApi/PackageUploaderService.cs
@@ -588,30 +588,36 @@ public class PackageUploaderService : IPackageUploaderService
 
     private async Task<GamePackage> WaitForPackageProcessingAsync(GameProduct product, GamePackage processingPackage, int minutesToWait, int checkIntervalMinutes, CancellationToken ct)
     {
-        await Task.Delay(TimeSpan.FromSeconds(5), ct).ConfigureAwait(false);
-        processingPackage = await _ingestionHttpClient.GetPackageByIdAsync(product.ProductId, processingPackage.Id, ct).ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromSeconds(10), ct).ConfigureAwait(false);
+        GamePackage internalPackage = await _ingestionHttpClient.GetPackageByIdAsync(product.ProductId, processingPackage.Id, ct).ConfigureAwait(false);
             
         var checkIntervalTimeSpan = TimeSpan.FromMinutes(checkIntervalMinutes);
         _logger.LogInformation("Will wait {minutesToWait} minute(s) for package processing, checking every {checkIntervalMinutes} minute(s).", minutesToWait, checkIntervalMinutes);
 
-        while (processingPackage.State is GamePackageState.InProcessing or GamePackageState.Uploaded or GamePackageState.Unknown && minutesToWait > 0)
+        while (internalPackage.State is GamePackageState.InProcessing or GamePackageState.Uploaded or GamePackageState.Unknown && minutesToWait > 0)
         {
             _logger.LogInformation("Package still in processing, waiting another {checkIntervalMinutes} minute(s). Will wait a further {minutesToWait} minute(s) after this.", checkIntervalMinutes, minutesToWait);
 
             await Task.Delay(checkIntervalTimeSpan, ct).ConfigureAwait(false);
 
-            processingPackage = await _ingestionHttpClient.GetPackageByIdAsync(product.ProductId, processingPackage.Id, ct).ConfigureAwait(false);
+            internalPackage = await _ingestionHttpClient.GetPackageByIdAsync(product.ProductId, internalPackage.Id, ct).ConfigureAwait(false);
 
             minutesToWait -= checkIntervalMinutes;
         }
 
-        _logger.LogInformation("Package state: {packageState}", processingPackage.State switch
+        _logger.LogInformation("Package state: {packageState}", internalPackage.State switch
         {
             GamePackageState.InProcessing => "In processing",
             GamePackageState.ProcessFailed => "Process failed",
             GamePackageState.PendingUpload => "Pending upload",
-            _ => processingPackage.State,
+            _ => internalPackage.State,
         });
+
+        if(processingPackage.Id != internalPackage.Id)
+        {
+            // Needed because 301 status returns what to query but not what we're currently uploading
+            processingPackage.State = internalPackage.State;
+        }
 
         return processingPackage;
     }


### PR DESCRIPTION
Created code to handle the 301 Error. Now, when it detects this, it assumes that it's due to a duplicate package, obtains the correct package ID for checking on the status, then updates the current upload package ID with the updated status. This enables developers to create a new package on partner center with a pre-existing/already uploaded msixvc file.