### PR TITLE
Fixing bug on XFUS Asset Id not displayed on errors

### DIFF
--- a/src/PackageUploader.ClientApi/Client/Xfus/Uploader/XfusApiController.cs
+++ b/src/PackageUploader.ClientApi/Client/Xfus/Uploader/XfusApiController.cs
@@ -101,6 +101,8 @@ internal class XfusApiController
 
     internal async Task<UploadProgress> InitializeAssetAsync(Guid assetId, FileInfo uploadFile, bool deltaUpload, CancellationToken ct)
     {
+        _logger.LogInformation("Calling XFUS with AssetId: {assetId}", assetId);
+
         var properties = new UploadProperties
         {
             FileProperties = new FileProperties
@@ -114,12 +116,12 @@ internal class XfusApiController
         using var cts = new CancellationTokenSource(_uploadConfig.HttpTimeoutMs);
 
         var response = await _httpClient.SendAsync(req, cts.Token).ConfigureAwait(false);
+        
         if (!response.IsSuccessStatusCode)
         {
             throw new XfusServerException(response.StatusCode, response.ReasonPhrase);
         }
 
-        _logger.LogInformation("XFUS AssetId: {assetId}", assetId);
         var uploadProgress = await response.Content.ReadFromJsonAsync(XfusJsonSerializerContext.Default.UploadProgress, ct).ConfigureAwait(false);
         return uploadProgress;
     }


### PR DESCRIPTION
 XFUS Asset Id was not displayed if send failed.