### PR TITLE
Users/suekim/hackathon

### DIFF
--- a/src/PackageUploader.Application/Operations/GetPackagesOperation.cs
+++ b/src/PackageUploader.Application/Operations/GetPackagesOperation.cs
@@ -23,6 +23,11 @@ internal class GetPackagesOperation : Operation
     private readonly ILogger<GetPackagesOperation> _logger;
     private readonly bool _isData;
     private readonly GetPackagesOperationConfig _config;
+    private readonly string _productIdOption;
+    private readonly string _bigIdOption;
+    private readonly string _branchFriendlyNameOption;
+    private readonly string _flightNameOption;
+    private readonly string _marketGroupNameOption;
 
     public GetPackagesOperation(IPackageUploaderService storeBrokerService, ILogger<GetPackagesOperation> logger, IOptions<GetPackagesOperationConfig> config, InvocationContext invocationContext) : base(logger)
     {
@@ -30,11 +35,50 @@ internal class GetPackagesOperation : Operation
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _isData = invocationContext.GetOptionValue(Program.DataOption);
         _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
+        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
+        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
+        _branchFriendlyNameOption = invocationContext.GetOptionValue(Program.BranchFriendlyNameOption);
+        _flightNameOption = invocationContext.GetOptionValue(Program.FlightNameOption);
+        _marketGroupNameOption = invocationContext.GetOptionValue(Program.MarketGroupNameOption);
+
+        // arg validations
+        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
+        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
+        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
+        if (_branchFriendlyNameOption != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both BranchFriendlyName and FlightName as optional arguments");
+        if (_config.BranchFriendlyName != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both: config value branchFriendlyName, optional argument FlightName");
+        if (_config.FlightName != null && _branchFriendlyNameOption != null) throw new ArgumentException("Cannot pass both: config value flightName, optional argument BranchFriendlyName");
     }
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
+
+        if (_productIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (productId) with {new}", _config.ProductId, _productIdOption);
+            _config.ProductId = _productIdOption;
+        }
+        if (_bigIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (bigId) with {new}", _config.BigId, _bigIdOption);
+            _config.BigId = _bigIdOption;
+        }
+        if (_branchFriendlyNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (branchFriendlyName) with {new}", _config.BranchFriendlyName, _branchFriendlyNameOption);
+            _config.BranchFriendlyName = _branchFriendlyNameOption;
+        }
+        if (_flightNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (flightName) with {new}", _config.FlightName, _flightNameOption);
+            _config.FlightName = _flightNameOption;
+        }
+        if (_marketGroupNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (marketGroupName) with {new}", _config.MarketGroupName, _marketGroupNameOption);
+            _config.MarketGroupName = _marketGroupNameOption;
+        }
 
         var product = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
         var packageBranch = await _storeBrokerService.GetGamePackageBranch(product, _config, ct).ConfigureAwait(false);

--- a/src/PackageUploader.Application/Operations/GetProductOperation.cs
+++ b/src/PackageUploader.Application/Operations/GetProductOperation.cs
@@ -20,18 +20,38 @@ internal class GetProductOperation : Operation
     private readonly ILogger<GetProductOperation> _logger;
     private readonly bool _isData;
     private readonly GetProductOperationConfig _config;
+    private readonly string _productIdOption;
+    private readonly string _bigIdOption;
 
     public GetProductOperation(IPackageUploaderService storeBrokerService, ILogger<GetProductOperation> logger, IOptions<GetProductOperationConfig> config, InvocationContext invocationContext) : base(logger)
     {
         _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _isData = invocationContext.GetOptionValue(Program.DataOption);
+        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
+        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
         _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
+
+        // arg validations
+        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
+        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
+        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
     }
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
+        
+        if (_productIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (Product ID) with {new}", _config.ProductId, _productIdOption);
+            _config.ProductId = _productIdOption;
+        }
+        if (_bigIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (Big ID) with {new}", _config.BigId, _bigIdOption);
+            _config.BigId = _bigIdOption;
+        }
 
         var gameProduct = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
         var gamePackageBranches = await _storeBrokerService.GetPackageBranchesAsync(gameProduct, ct).ConfigureAwait(false);

--- a/src/PackageUploader.Application/Operations/ImportPackagesOperation.cs
+++ b/src/PackageUploader.Application/Operations/ImportPackagesOperation.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.CommandLine.Invocation;
 
 namespace PackageUploader.Application.Operations;
 
@@ -17,17 +18,61 @@ internal class ImportPackagesOperation : Operation
     private readonly IPackageUploaderService _storeBrokerService;
     private readonly ILogger<ImportPackagesOperation> _logger;
     private readonly ImportPackagesOperationConfig _config;
+    private readonly string _productIdOption;
+    private readonly string _bigIdOption;
+    private readonly string _branchFriendlyNameOption;
+    private readonly string _flightNameOption;
+    private readonly string _marketGroupNameOption;
 
-    public ImportPackagesOperation(IPackageUploaderService storeBrokerService, ILogger<ImportPackagesOperation> logger, IOptions<ImportPackagesOperationConfig> config) : base(logger)
+    public ImportPackagesOperation(IPackageUploaderService storeBrokerService, ILogger<ImportPackagesOperation> logger, IOptions<ImportPackagesOperationConfig> config, InvocationContext invocationContext) : base(logger)
     {
         _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
+        _config = config?.Value ?? throw new ArgumentNullException(nameof(config)); 
+        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
+        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
+        _branchFriendlyNameOption = invocationContext.GetOptionValue(Program.BranchFriendlyNameOption);
+        _flightNameOption = invocationContext.GetOptionValue(Program.FlightNameOption);
+        _marketGroupNameOption = invocationContext.GetOptionValue(Program.MarketGroupNameOption);
+
+        // arg validations
+        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
+        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
+        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
+        if (_branchFriendlyNameOption != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both BranchFriendlyName and FlightName as optional arguments");
+        if (_config.BranchFriendlyName != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both: config value branchFriendlyName, optional argument FlightName");
+        if (_config.FlightName != null && _branchFriendlyNameOption != null) throw new ArgumentException("Cannot pass both: config value flightName, optional argument BranchFriendlyName");
     }
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
+
+        if (_productIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (productId) with {new}", _config.ProductId, _productIdOption);
+            _config.ProductId = _productIdOption;
+        }
+        if (_bigIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (bigId) with {new}", _config.BigId, _bigIdOption);
+            _config.BigId = _bigIdOption;
+        }
+        if (_branchFriendlyNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (branchFriendlyName) with {new}", _config.BranchFriendlyName, _branchFriendlyNameOption);
+            _config.BranchFriendlyName = _branchFriendlyNameOption;
+        }
+        if (_flightNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (flightName) with {new}", _config.FlightName, _flightNameOption);
+            _config.FlightName = _flightNameOption;
+        }
+        if (_marketGroupNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (marketGroupName) with {new}", _config.MarketGroupName, _marketGroupNameOption);
+            _config.MarketGroupName = _marketGroupNameOption;
+        }
 
         var product = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
         var originPackageBranch = await _storeBrokerService.GetGamePackageBranch(product, _config, ct).ConfigureAwait(false);

--- a/src/PackageUploader.Application/Operations/PublishPackagesOperation.cs
+++ b/src/PackageUploader.Application/Operations/PublishPackagesOperation.cs
@@ -11,6 +11,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.CommandLine.Invocation;
 
 namespace PackageUploader.Application.Operations;
 
@@ -19,17 +20,61 @@ internal sealed class PublishPackagesOperation : Operation
     private readonly IPackageUploaderService _storeBrokerService;
     private readonly ILogger<PublishPackagesOperation> _logger;
     private readonly PublishPackagesOperationConfig _config;
+    private readonly string _productIdOption;
+    private readonly string _bigIdOption;
+    private readonly string _branchFriendlyNameOption;
+    private readonly string _flightNameOption;
+    private readonly string _destinationSandboxName;
 
-    public PublishPackagesOperation(IPackageUploaderService storeBrokerService, ILogger<PublishPackagesOperation> logger, IOptions<PublishPackagesOperationConfig> config) : base(logger)
+    public PublishPackagesOperation(IPackageUploaderService storeBrokerService, ILogger<PublishPackagesOperation> logger, IOptions<PublishPackagesOperationConfig> config, InvocationContext invocationContext) : base(logger)
     {
         _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
+        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
+        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
+        _branchFriendlyNameOption = invocationContext.GetOptionValue(Program.BranchFriendlyNameOption);
+        _flightNameOption = invocationContext.GetOptionValue(Program.FlightNameOption);
+        _destinationSandboxName = invocationContext.GetOptionValue(Program.DestinationSandboxName);
+
+        // arg validations
+        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
+        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
+        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
+        if (_branchFriendlyNameOption != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both BranchFriendlyName and FlightName as optional arguments");
+        if (_destinationSandboxName != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both DestinationSandboxName and FlightName as optional arguments");
+        if ((_config.BranchFriendlyName != null && _config.DestinationSandboxName != null) && _flightNameOption != null) throw new ArgumentException("Cannot pass both: (config values branchFriendlyName and destinationSandboxName), optional argument FlightName");
+        if (_config.FlightName != null && (_branchFriendlyNameOption != null && _destinationSandboxName != null)) throw new ArgumentException("Cannot pass both: config value flightName, (optional argument BranchFriendlyName and DestinationSandboxName)");
     }
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
+
+        if (_productIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (productId) with {new}", _config.ProductId, _productIdOption);
+            _config.ProductId = _productIdOption;
+        }
+        if (_bigIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (bigId) with {new}", _config.BigId, _bigIdOption);
+            _config.BigId = _bigIdOption;
+        }
+        if (_branchFriendlyNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (branchFriendlyName) with {new}", _config.BranchFriendlyName, _branchFriendlyNameOption);
+            _config.BranchFriendlyName = _branchFriendlyNameOption;
+        }
+        if (_flightNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (flightName) with {new}", _config.FlightName, _flightNameOption);
+            _config.FlightName = _flightNameOption;
+        }
+        if (_destinationSandboxName != null) {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (destinationSandboxName) with {new}", _config.DestinationSandboxName, _destinationSandboxName);
+            _config.DestinationSandboxName = _destinationSandboxName;
+        }
 
         var product = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
 

--- a/src/PackageUploader.Application/Operations/RemovePackagesOperation.cs
+++ b/src/PackageUploader.Application/Operations/RemovePackagesOperation.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.CommandLine.Invocation;
 
 namespace PackageUploader.Application.Operations;
 
@@ -17,17 +18,61 @@ internal class RemovePackagesOperation : Operation
     private readonly IPackageUploaderService _storeBrokerService;
     private readonly ILogger<RemovePackagesOperation> _logger;
     private readonly RemovePackagesOperationConfig _config;
+    private readonly string _productIdOption;
+    private readonly string _bigIdOption;
+    private readonly string _branchFriendlyNameOption;
+    private readonly string _flightNameOption;
+    private readonly string _marketGroupNameOption;
 
-    public RemovePackagesOperation(IPackageUploaderService storeBrokerService, ILogger<RemovePackagesOperation> logger, IOptions<RemovePackagesOperationConfig> config) : base(logger)
+    public RemovePackagesOperation(IPackageUploaderService storeBrokerService, ILogger<RemovePackagesOperation> logger, IOptions<RemovePackagesOperationConfig> config, InvocationContext invocationContext) : base(logger)
     {
         _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
+        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
+        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
+        _branchFriendlyNameOption = invocationContext.GetOptionValue(Program.BranchFriendlyNameOption);
+        _flightNameOption = invocationContext.GetOptionValue(Program.FlightNameOption);
+        _marketGroupNameOption = invocationContext.GetOptionValue(Program.MarketGroupNameOption);
+
+        // arg validations
+        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
+        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
+        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
+        if (_branchFriendlyNameOption != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both BranchFriendlyName and FlightName as optional arguments");
+        if (_config.BranchFriendlyName != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both: config value branchFriendlyName, optional argument FlightName");
+        if (_config.FlightName != null && _branchFriendlyNameOption != null) throw new ArgumentException("Cannot pass both: config value flightName, optional argument BranchFriendlyName");
     }
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
+
+        if (_productIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (productId) with {new}", _config.ProductId, _productIdOption);
+            _config.ProductId = _productIdOption;
+        }
+        if (_bigIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (bigId) with {new}", _config.BigId, _bigIdOption);
+            _config.BigId = _bigIdOption;
+        }
+        if (_branchFriendlyNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (branchFriendlyName) with {new}", _config.BranchFriendlyName, _branchFriendlyNameOption);
+            _config.BranchFriendlyName = _branchFriendlyNameOption;
+        }
+        if (_flightNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (flightName) with {new}", _config.FlightName, _flightNameOption);
+            _config.FlightName = _flightNameOption;
+        }
+        if (_marketGroupNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (marketGroupName) with {new}", _config.MarketGroupName, _marketGroupNameOption);
+            _config.MarketGroupName = _marketGroupNameOption;
+        }
 
         var product = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
         var packageBranch = await _storeBrokerService.GetGamePackageBranch(product, _config, ct).ConfigureAwait(false);

--- a/src/PackageUploader.Application/Operations/UploadUwpPackageOperation.cs
+++ b/src/PackageUploader.Application/Operations/UploadUwpPackageOperation.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.CommandLine.Invocation;
 
 namespace PackageUploader.Application.Operations;
 
@@ -17,17 +18,61 @@ internal class UploadUwpPackageOperation : Operation
     private readonly IPackageUploaderService _storeBrokerService;
     private readonly ILogger<UploadUwpPackageOperation> _logger;
     private readonly UploadUwpPackageOperationConfig _config;
+    private readonly string _productIdOption;
+    private readonly string _bigIdOption;
+    private readonly string _branchFriendlyNameOption;
+    private readonly string _flightNameOption;
+    private readonly string _marketGroupNameOption;
 
-    public UploadUwpPackageOperation(IPackageUploaderService storeBrokerService, ILogger<UploadUwpPackageOperation> logger, IOptions<UploadUwpPackageOperationConfig> config) : base(logger)
+    public UploadUwpPackageOperation(IPackageUploaderService storeBrokerService, ILogger<UploadUwpPackageOperation> logger, IOptions<UploadUwpPackageOperationConfig> config, InvocationContext invocationContext) : base(logger)
     {
         _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
+        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
+        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
+        _branchFriendlyNameOption = invocationContext.GetOptionValue(Program.BranchFriendlyNameOption);
+        _flightNameOption = invocationContext.GetOptionValue(Program.FlightNameOption);
+        _marketGroupNameOption = invocationContext.GetOptionValue(Program.MarketGroupNameOption);
+
+        // arg validations
+        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
+        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
+        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
+        if (_branchFriendlyNameOption != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both BranchFriendlyName and FlightName as optional arguments");
+        if (_config.BranchFriendlyName != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both: config value branchFriendlyName, optional argument FlightName");
+        if (_config.FlightName != null && _branchFriendlyNameOption != null) throw new ArgumentException("Cannot pass both: config value flightName, optional argument BranchFriendlyName");
     }
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
+
+        if (_productIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (productId) with {new}", _config.ProductId, _productIdOption);
+            _config.ProductId = _productIdOption;
+        }
+        if (_bigIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (bigId) with {new}", _config.BigId, _bigIdOption);
+            _config.BigId = _bigIdOption;
+        }
+        if (_branchFriendlyNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (branchFriendlyName) with {new}", _config.BranchFriendlyName, _branchFriendlyNameOption);
+            _config.BranchFriendlyName = _branchFriendlyNameOption;
+        }
+        if (_flightNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (flightName) with {new}", _config.FlightName, _flightNameOption);
+            _config.FlightName = _flightNameOption;
+        }
+        if (_marketGroupNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (marketGroupName) with {new}", _config.MarketGroupName, _marketGroupNameOption);
+            _config.MarketGroupName = _marketGroupNameOption;
+        }
 
         var product = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
         var packageBranch = await _storeBrokerService.GetGamePackageBranch(product, _config, ct).ConfigureAwait(false);

--- a/src/PackageUploader.Application/Operations/UploadXvcPackageOperation.cs
+++ b/src/PackageUploader.Application/Operations/UploadXvcPackageOperation.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.CommandLine.Invocation;
 
 namespace PackageUploader.Application.Operations;
 
@@ -17,17 +18,61 @@ internal class UploadXvcPackageOperation : Operation
     private readonly IPackageUploaderService _storeBrokerService;
     private readonly ILogger<UploadXvcPackageOperation> _logger;
     private readonly UploadXvcPackageOperationConfig _config;
+    private readonly string _productIdOption;
+    private readonly string _bigIdOption;
+    private readonly string _branchFriendlyNameOption;
+    private readonly string _flightNameOption;
+    private readonly string _marketGroupNameOption;
 
-    public UploadXvcPackageOperation(IPackageUploaderService storeBrokerService, ILogger<UploadXvcPackageOperation> logger, IOptions<UploadXvcPackageOperationConfig> config) : base(logger)
+    public UploadXvcPackageOperation(IPackageUploaderService storeBrokerService, ILogger<UploadXvcPackageOperation> logger, IOptions<UploadXvcPackageOperationConfig> config, InvocationContext invocationContext) : base(logger)
     {
         _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
+        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
+        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
+        _branchFriendlyNameOption = invocationContext.GetOptionValue(Program.BranchFriendlyNameOption);
+        _flightNameOption = invocationContext.GetOptionValue(Program.FlightNameOption);
+        _marketGroupNameOption = invocationContext.GetOptionValue(Program.MarketGroupNameOption);
+
+        // arg validations
+        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
+        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
+        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
+        if (_branchFriendlyNameOption != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both BranchFriendlyName and FlightName as optional arguments");
+        if (_config.BranchFriendlyName != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both: config value branchFriendlyName, optional argument FlightName");
+        if (_config.FlightName != null && _branchFriendlyNameOption != null) throw new ArgumentException("Cannot pass both: config value flightName, optional argument BranchFriendlyName");
     }
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
+
+        if (_productIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (productId) with {new}", _config.ProductId, _productIdOption);
+            _config.ProductId = _productIdOption;
+        }
+        if (_bigIdOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (bigId) with {new}", _config.BigId, _bigIdOption);
+            _config.BigId = _bigIdOption;
+        }
+        if (_branchFriendlyNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (branchFriendlyName) with {new}", _config.BranchFriendlyName, _branchFriendlyNameOption);
+            _config.BranchFriendlyName = _branchFriendlyNameOption;
+        }
+        if (_flightNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (flightName) with {new}", _config.FlightName, _flightNameOption);
+            _config.FlightName = _flightNameOption;
+        }
+        if (_marketGroupNameOption != null)
+        {
+            _logger.LogInformation("Optional argument passed. Replacing config value {old} (marketGroupName) with {new}", _config.MarketGroupName, _marketGroupNameOption);
+            _config.MarketGroupName = _marketGroupNameOption;
+        }
 
         var product = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
         var packageBranch = await _storeBrokerService.GetGamePackageBranch(product, _config, ct).ConfigureAwait(false);

--- a/src/PackageUploader.Application/Program.cs
+++ b/src/PackageUploader.Application/Program.cs
@@ -32,6 +32,13 @@ internal class Program
     private static readonly Option<string> ClientSecretOption = new (["-s", "--ClientSecret"], "The client secret of the AAD app (only for AppSecret)");
     private static readonly Option<FileInfo> ConfigFileOption = new Option<FileInfo>(["-c", "--ConfigFile"], "The location of the config file").Required();
     private static readonly Option<IngestionExtensions.AuthenticationMethod> AuthenticationMethodOption = new(["-a", "--Authentication"], () => IngestionExtensions.AuthenticationMethod.AppSecret, "The authentication method");
+    public static readonly Option<string> ProductIdOption = new(["-p", "--ProductId"], "Product ID, replaces config value productId if present");
+    public static readonly Option<string> BigIdOption = new(["-b", "--BigId"], "Big ID, replaces config value bigId if present");
+    public static readonly Option<string> BranchFriendlyNameOption = new(["-bf", "--BranchFriendlyName"], "Branch Friendly Name, replaces config value branchFriendlyName if present");
+    public static readonly Option<string> FlightNameOption = new(["-f", "--FlightName"], "Flight Name, replaces config value flightName if present");
+    public static readonly Option<string> MarketGroupNameOption = new(["-m", "--MarketGroupName"], "Market Group Name, replaces config value marketGroupName if present");
+    public static readonly Option<string> DestinationSandboxName = new(["-ds", "--DestinationSandboxName"], "Destination Sandbox Name, replaces config value destinationSandboxName if present");
+
 
     private static async Task<int> Main(string[] args)
     {
@@ -111,31 +118,31 @@ internal class Program
         {
             new Command("GetProduct", "Gets metadata of the product")
             {
-                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption, DataOption
+                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption, DataOption, ProductIdOption, BigIdOption
             }.AddOperationHandler<GetProductOperation>(),
             new Command("UploadUwpPackage", "Uploads Uwp game package")
             {
-                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption
+                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption, ProductIdOption, BigIdOption, BranchFriendlyNameOption, FlightNameOption, MarketGroupNameOption
             }.AddOperationHandler<UploadUwpPackageOperation>(),
             new Command("UploadXvcPackage", "Uploads Xvc game package and assets")
             {
-                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption
+                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption, ProductIdOption, BigIdOption, BranchFriendlyNameOption, FlightNameOption, MarketGroupNameOption
             }.AddOperationHandler<UploadXvcPackageOperation>(),
             new Command("RemovePackages", "Removes all game packages and assets from a branch")
             {
-                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption
+                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption, ProductIdOption, BigIdOption, BranchFriendlyNameOption, FlightNameOption, MarketGroupNameOption
             }.AddOperationHandler<RemovePackagesOperation>(),
             new Command("ImportPackages", "Imports all game packages from a branch to a destination branch")
             {
-                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption
+                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption, ProductIdOption, BigIdOption, BranchFriendlyNameOption, FlightNameOption, MarketGroupNameOption
             }.AddOperationHandler<ImportPackagesOperation>(),
             new Command("PublishPackages", "Publishes all game packages from a branch or flight to a destination sandbox or flight")
             {
-                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption
+                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption, ProductIdOption, BigIdOption, BranchFriendlyNameOption, FlightNameOption, DestinationSandboxName // take a look at conditions
             }.AddOperationHandler<PublishPackagesOperation>(),
             new Command("GetPackages", "Gets the list of packages from a branch or flight")
             {
-                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption, DataOption
+                ConfigFileOption, ClientSecretOption, AuthenticationMethodOption, DataOption, ProductIdOption, BigIdOption, BranchFriendlyNameOption, FlightNameOption, MarketGroupNameOption
             }.AddOperationHandler<GetPackagesOperation>(),
         };
         rootCommand.AddGlobalOption(VerboseOption);

--- a/src/PackageUploader.Application/packages.lock.json
+++ b/src/PackageUploader.Application/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "CCIhseY9KUJDIYKt7qD1IRLQA6Hr/8Dky31KS6UrM2sFyaFUb2JLagT0Uy2BiSf1i1Qy3nPjRb0zc1JFogOi9w=="
+        "requested": "[8.0.15, )",
+        "resolved": "8.0.15",
+        "contentHash": "wMf2N7fJ846aKd73R5gqvtbyqu89/LywlWCtMyXUqKYc9DR3s9kUgNrLIsT9KeRwyinGFJDtRbiib0M4YBX6ZA=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Direct",
@@ -71,9 +71,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.15, )",
+        "resolved": "8.0.15",
+        "contentHash": "s4eXlcRGyHeCgFUGQnhq0e/SCHBPp0jOHgMqZg3fQ2OCHJSm1aOUhI6RFWuVIcEb9ig2WgI2kWukk8wu72EbUQ=="
       },
       "System.CommandLine.Hosting": {
         "type": "Direct",
@@ -530,17 +530,17 @@
     "net8.0/linux-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "CCIhseY9KUJDIYKt7qD1IRLQA6Hr/8Dky31KS6UrM2sFyaFUb2JLagT0Uy2BiSf1i1Qy3nPjRb0zc1JFogOi9w==",
+        "requested": "[8.0.15, )",
+        "resolved": "8.0.15",
+        "contentHash": "wMf2N7fJ846aKd73R5gqvtbyqu89/LywlWCtMyXUqKYc9DR3s9kUgNrLIsT9KeRwyinGFJDtRbiib0M4YBX6ZA==",
         "dependencies": {
-          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "8.0.13"
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "8.0.15"
         }
       },
       "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "8.0.13",
-        "contentHash": "F/6J0r8N7VVL4AJHdawVFj4XxB/r1rw0oD0txuK6Om+m/SuidnGTGl2APUeZgqOtNtsIVYtL3L3jBYbo02xFeA=="
+        "resolved": "8.0.15",
+        "contentHash": "cd6zPkPgS2OZflyVM3n4UR3YowbTDCIAQHI+tHMUHITa6XTTzyrWiqmvo42Oh7NPu04C7SKqEiT2WbdajYoi/w=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -564,17 +564,17 @@
     "net8.0/win-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "CCIhseY9KUJDIYKt7qD1IRLQA6Hr/8Dky31KS6UrM2sFyaFUb2JLagT0Uy2BiSf1i1Qy3nPjRb0zc1JFogOi9w==",
+        "requested": "[8.0.15, )",
+        "resolved": "8.0.15",
+        "contentHash": "wMf2N7fJ846aKd73R5gqvtbyqu89/LywlWCtMyXUqKYc9DR3s9kUgNrLIsT9KeRwyinGFJDtRbiib0M4YBX6ZA==",
         "dependencies": {
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "8.0.13"
+          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "8.0.15"
         }
       },
       "runtime.win-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "8.0.13",
-        "contentHash": "4M/96PlMWH0ysnPe+q4iZvGvIREeJsRXFsfANU2qVg3cyTCp+cGX4Sa7Inu2/MfV9+nx98oYBDAgiJvyig9plg=="
+        "resolved": "8.0.15",
+        "contentHash": "WTC2bvstnJztrKdeF+ILz5cEe3C8gpoft5BRmquaEfvTDT+N/YrqzLLXLKUmtQb5w1M4i8tYGHg2rOqJ0UsPrA=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",

--- a/src/PackageUploader.ClientApi/Client/Ingestion/Client/HttpRestClient.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/Client/HttpRestClient.cs
@@ -53,6 +53,11 @@ internal abstract class HttpRestClient : IHttpRestClient
             var result = await response.Content.ReadFromJsonAsync(jsonTypeInfo, ct).ConfigureAwait(false);
             return result;
         }
+        catch (HttpRequestException e) when (e.StatusCode is HttpStatusCode.NotFound && Regex.Match(subUrl, "products/[\\w]+$").Success) 
+        {
+            // This doesn't need logged, similar to behavior when a product is not found by Big ID
+            throw;
+        }
         catch (Exception ex)
         {
             LogException(ex);

--- a/src/PackageUploader.ClientApi/packages.lock.json
+++ b/src/PackageUploader.ClientApi/packages.lock.json
@@ -97,9 +97,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.15, )",
+        "resolved": "8.0.15",
+        "contentHash": "s4eXlcRGyHeCgFUGQnhq0e/SCHBPp0jOHgMqZg3fQ2OCHJSm1aOUhI6RFWuVIcEb9ig2WgI2kWukk8wu72EbUQ=="
       },
       "Polly.Contrib.WaitAndRetry": {
         "type": "Direct",

--- a/src/PackageUploader.FileLogger/packages.lock.json
+++ b/src/PackageUploader.FileLogger/packages.lock.json
@@ -31,9 +31,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.13, )",
-        "resolved": "8.0.13",
-        "contentHash": "R19ZTaRiQAK+xo9ZwaHbF/1vb1wwR1Wn5+sqp9v8+CDjbdS8R6qftKdw0VSXWKm7VAMi7P+NCU4zxDzhEWcAwQ=="
+        "requested": "[8.0.15, )",
+        "resolved": "8.0.15",
+        "contentHash": "s4eXlcRGyHeCgFUGQnhq0e/SCHBPp0jOHgMqZg3fQ2OCHJSm1aOUhI6RFWuVIcEb9ig2WgI2kWukk8wu72EbUQ=="
       },
       "System.Text.Json": {
         "type": "Direct",


### PR DESCRIPTION
Added optional arguments to all operations and their corresponding commands. These arguments only replace existing config values if present and cannot be passed if the config value doesn't exist or if the config has conflicting params. The validations done are intended to be consistent with those done via dependency injection for config values.

New optional arguments

- Product ID
- Big ID
- Branch Friendly Name
- Flight Name 
- Market Group Name
- Destination Sandbox Name

My hackathon project is targeting this [Scenario 56127432](https://microsoft.visualstudio.com/Xbox/_workitems/edit/56127432)

P.S. Also "fixed" a UX inconsistency where calling getProductAsync via GetProductByBigIdAsync with an invalid ID would print a message like "Product with big id '9FAKEBIGID ' not found." But calling via GetGameProductByLongIdAsync would print the message and also an entire exception stack (of a 404 not found) which clogs the stdout and is not useful for the customer.Added optional arguments to all operations and their corresponding commands. These arguments only replace existing config values if present and cannot be passed if the config value doesn't exist or if the config has conflicting params. The validations done are intended to be consistent with those done via dependency injection for config values.