### PR TITLE
Fix for empty DateTime value

### DIFF
--- a/src/PackageUploader.Application/Config/ImportPackagesOperationConfig.cs
+++ b/src/PackageUploader.Application/Config/ImportPackagesOperationConfig.cs
@@ -47,7 +47,7 @@ internal class ImportPackagesOperationConfig : PackageBranchOperationConfig, IGa
             yield return new ValidationResult($"{nameof(PreDownloadDate)} needs {nameof(AvailabilityDate)}.", [nameof(PreDownloadDate), nameof(AvailabilityDate)]);
         }
 
-        if (PreDownloadDate?.IsEnabled == true && AvailabilityDate?.IsEnabled == true && PreDownloadDate.EffectiveDate > AvailabilityDate.EffectiveDate)
+        if (PreDownloadDate?.IsEnabled == true && AvailabilityDate?.IsEnabled == true && PreDownloadDate.GetEffectiveDate() > AvailabilityDate.GetEffectiveDate())
         {
             yield return new ValidationResult($"{nameof(PreDownloadDate)} needs to be before {nameof(AvailabilityDate)}.", [nameof(PreDownloadDate), nameof(AvailabilityDate)]);
         }

--- a/src/PackageUploader.Application/Config/UploadXvcPackageOperationConfig.cs
+++ b/src/PackageUploader.Application/Config/UploadXvcPackageOperationConfig.cs
@@ -38,7 +38,7 @@ internal class UploadXvcPackageOperationConfig : UploadPackageOperationConfig, I
             yield return new ValidationResult($"{nameof(PreDownloadDate)} needs {nameof(AvailabilityDate)}.", [nameof(PreDownloadDate), nameof(AvailabilityDate)]);
         }
 
-        if (PreDownloadDate?.IsEnabled == true && AvailabilityDate?.IsEnabled == true && PreDownloadDate.EffectiveDate > AvailabilityDate.EffectiveDate)
+        if (PreDownloadDate?.IsEnabled == true && AvailabilityDate?.IsEnabled == true && PreDownloadDate.GetEffectiveDate() > AvailabilityDate.GetEffectiveDate())
         {
             yield return new ValidationResult($"{nameof(PreDownloadDate)} needs to be before {nameof(AvailabilityDate)}.", [nameof(PreDownloadDate), nameof(AvailabilityDate)]);
         }

--- a/src/PackageUploader.Application/packages.lock.json
+++ b/src/PackageUploader.Application/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.15, )",
-        "resolved": "8.0.15",
-        "contentHash": "wMf2N7fJ846aKd73R5gqvtbyqu89/LywlWCtMyXUqKYc9DR3s9kUgNrLIsT9KeRwyinGFJDtRbiib0M4YBX6ZA=="
+        "requested": "[8.0.14, )",
+        "resolved": "8.0.14",
+        "contentHash": "lJvndCQZJxHBVoD8VxfSJ2MaURHENC63sbeAJNfedvXvscgjQSpfVdcTsv0iGeSu9X05G05TYMCWVbZGj4Z51Q=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Direct",
@@ -530,17 +530,17 @@
     "net8.0/linux-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.15, )",
-        "resolved": "8.0.15",
-        "contentHash": "wMf2N7fJ846aKd73R5gqvtbyqu89/LywlWCtMyXUqKYc9DR3s9kUgNrLIsT9KeRwyinGFJDtRbiib0M4YBX6ZA==",
+        "requested": "[8.0.14, )",
+        "resolved": "8.0.14",
+        "contentHash": "lJvndCQZJxHBVoD8VxfSJ2MaURHENC63sbeAJNfedvXvscgjQSpfVdcTsv0iGeSu9X05G05TYMCWVbZGj4Z51Q==",
         "dependencies": {
-          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "8.0.15"
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "8.0.14"
         }
       },
       "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "8.0.15",
-        "contentHash": "cd6zPkPgS2OZflyVM3n4UR3YowbTDCIAQHI+tHMUHITa6XTTzyrWiqmvo42Oh7NPu04C7SKqEiT2WbdajYoi/w=="
+        "resolved": "8.0.14",
+        "contentHash": "Jjg/BY6zn1IZ3dEqR6Dgp9YPXyPT3FxvjhZb/H1YNWj7rKkEMpfnFkPK+2zw/ccTJhoOv48TUkydkbx1/o3KEw=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -564,17 +564,17 @@
     "net8.0/win-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.15, )",
-        "resolved": "8.0.15",
-        "contentHash": "wMf2N7fJ846aKd73R5gqvtbyqu89/LywlWCtMyXUqKYc9DR3s9kUgNrLIsT9KeRwyinGFJDtRbiib0M4YBX6ZA==",
+        "requested": "[8.0.14, )",
+        "resolved": "8.0.14",
+        "contentHash": "lJvndCQZJxHBVoD8VxfSJ2MaURHENC63sbeAJNfedvXvscgjQSpfVdcTsv0iGeSu9X05G05TYMCWVbZGj4Z51Q==",
         "dependencies": {
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "8.0.15"
+          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "8.0.14"
         }
       },
       "runtime.win-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "8.0.15",
-        "contentHash": "WTC2bvstnJztrKdeF+ILz5cEe3C8gpoft5BRmquaEfvTDT+N/YrqzLLXLKUmtQb5w1M4i8tYGHg2rOqJ0UsPrA=="
+        "resolved": "8.0.14",
+        "contentHash": "R8sYSj9FIf+miUFL5Db2fAcvcguU2K4a0d0NLuZKyvxsPHKRD25ag0QbWR0fDaURXEB8YjfPEBagxr1uIFWTTQ=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",

--- a/src/PackageUploader.ClientApi/Models/GamePackageDate.cs
+++ b/src/PackageUploader.ClientApi/Models/GamePackageDate.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 
 namespace PackageUploader.ClientApi.Models;
 
@@ -9,11 +10,33 @@ public class GamePackageDate
 {
     public bool IsEnabled { get; set; }
 
-    private DateTime? _effectiveDate;
-    public DateTime? EffectiveDate
+    private string _effectiveDate = null!;
+    public string EffectiveDate
     {
         get => _effectiveDate;
-        set => _effectiveDate = GetUtcDateWithHour(value);
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                _effectiveDate = null;
+                return;
+            }
+
+            // Do a parse here to ensure this value is valid up front rather than throwing an exception later when it's first
+            // used. We avoid making EffectiveDate a DateTime? directly because the parse code will then throw an exception on
+            // an empty string, which we'd rather treat as 'null'.
+            _ = DateTime.Parse(value, CultureInfo.InvariantCulture);
+            _effectiveDate = value;
+        }
+    }
+
+    public DateTime? GetEffectiveDate()
+    {
+        if (string.IsNullOrWhiteSpace(EffectiveDate))
+        {
+            return null;
+        }
+        return GetUtcDateWithHour(DateTime.Parse(EffectiveDate, CultureInfo.InvariantCulture));
     }
 
     private static DateTime? GetUtcDateWithHour(DateTime? dateTime)

--- a/src/PackageUploader.ClientApi/PackageUploaderService.cs
+++ b/src/PackageUploader.ClientApi/PackageUploaderService.cs
@@ -301,7 +301,7 @@ public class PackageUploaderService : IPackageUploaderService
                     if (gameConfiguration.AvailabilityDate.IsEnabled)
                     {
                         marketGroupPackage.PackageAvailabilityDates ??= [];
-                        marketGroupPackage.PackageAvailabilityDates[gamePackage.Id] = gameConfiguration.AvailabilityDate.EffectiveDate;
+                        marketGroupPackage.PackageAvailabilityDates[gamePackage.Id] = gameConfiguration.AvailabilityDate.GetEffectiveDate();
                     }
                     else if (marketGroupPackage.PackageAvailabilityDates is not null)
                     {
@@ -344,7 +344,7 @@ public class PackageUploaderService : IPackageUploaderService
                     if (gameConfiguration.AvailabilityDate is not null)
                     {
                         marketGroupPackage.AvailabilityDate = gameConfiguration.AvailabilityDate.IsEnabled
-                            ? gameConfiguration.AvailabilityDate.EffectiveDate
+                            ? gameConfiguration.AvailabilityDate.GetEffectiveDate()
                             : null;
                     }
 
@@ -354,7 +354,7 @@ public class PackageUploaderService : IPackageUploaderService
                         marketGroupPackage.MandatoryUpdateInfo = new GameMandatoryUpdateInfo
                         {
                             IsEnabled = gameConfiguration.MandatoryDate.IsEnabled,
-                            EffectiveDate = gameConfiguration.MandatoryDate.EffectiveDate,
+                            EffectiveDate = gameConfiguration.MandatoryDate.GetEffectiveDate(),
                         };
                     }
                 }
@@ -439,7 +439,7 @@ public class PackageUploaderService : IPackageUploaderService
                                     if (gameConfiguration?.AvailabilityDate is not null)
                                     {
                                         destinationMarketGroupPackage.PackageAvailabilityDates[packageId] = gameConfiguration.AvailabilityDate.IsEnabled
-                                            ? gameConfiguration.AvailabilityDate.EffectiveDate
+                                            ? gameConfiguration.AvailabilityDate.GetEffectiveDate()
                                             : null;
                                     }
                                     else
@@ -466,7 +466,7 @@ public class PackageUploaderService : IPackageUploaderService
                                     if (gameConfiguration?.AvailabilityDate is not null)
                                     {
                                         destinationMarketGroupPackage.PackageAvailabilityDates[packageId] = gameConfiguration.AvailabilityDate.IsEnabled
-                                            ? gameConfiguration.AvailabilityDate.EffectiveDate
+                                            ? gameConfiguration.AvailabilityDate.GetEffectiveDate()
                                             : null;
                                     }
                                     else
@@ -491,7 +491,7 @@ public class PackageUploaderService : IPackageUploaderService
                             if (gameConfiguration.AvailabilityDate is not null)
                             {
                                 destinationMarketGroupPackage.AvailabilityDate = gameConfiguration.AvailabilityDate.IsEnabled
-                                    ? gameConfiguration.AvailabilityDate.EffectiveDate
+                                    ? gameConfiguration.AvailabilityDate.GetEffectiveDate()
                                     : null;
                             }
                             if (gameConfiguration.MandatoryDate is not null)
@@ -499,7 +499,7 @@ public class PackageUploaderService : IPackageUploaderService
                                 destinationMarketGroupPackage.MandatoryUpdateInfo = new GameMandatoryUpdateInfo
                                 {
                                     IsEnabled = gameConfiguration.MandatoryDate.IsEnabled,
-                                    EffectiveDate = gameConfiguration.MandatoryDate.EffectiveDate,
+                                    EffectiveDate = gameConfiguration.MandatoryDate.GetEffectiveDate(),
                                 };
                             }
                         }
@@ -510,7 +510,7 @@ public class PackageUploaderService : IPackageUploaderService
                             {
                                 destinationMarketGroupPackage.AvailabilityDate =
                                     gameConfiguration.AvailabilityDate.IsEnabled
-                                        ? gameConfiguration.AvailabilityDate.EffectiveDate
+                                        ? gameConfiguration.AvailabilityDate.GetEffectiveDate()
                                         : null;
                             }
 
@@ -521,7 +521,7 @@ public class PackageUploaderService : IPackageUploaderService
                                 destinationMarketGroupPackage.MandatoryUpdateInfo = new GameMandatoryUpdateInfo
                                 {
                                     IsEnabled = gameConfiguration.MandatoryDate.IsEnabled,
-                                    EffectiveDate = gameConfiguration.MandatoryDate.EffectiveDate,
+                                    EffectiveDate = gameConfiguration.MandatoryDate.GetEffectiveDate(),
                                 };
                             }
                         }
@@ -689,7 +689,7 @@ public class PackageUploaderService : IPackageUploaderService
     {
         return new GameMarketGroupPackageMetadata
         {
-            PreDownloadDate = preDownloadDate?.IsEnabled == true ? preDownloadDate.EffectiveDate : null,
+            PreDownloadDate = preDownloadDate?.IsEnabled == true ? preDownloadDate.GetEffectiveDate() : null,
         };
     }
 


### PR DESCRIPTION
When the config parsing logic got updated to .NET 8 it caused a breaking change to how DateTime gets parsed, meaning an empty string was no longer accepted and now resulted in an exception. See Issue #60 .

One possible fix is to make EffectiveDate a string instead and replace uses with GetEffectiveDate that converts it to a DateTime at that point. To keep behavior close when the value is bad, we can also do a parse in EffectiveDate to ensure it's a valid value (if not null or empty) so the failure will still be up-front during configuration loading.