### PR TITLE
Simplify command line arguments logic

### DIFF
--- a/src/PackageUploader.Application/Extensions/ProgramExtensions.cs
+++ b/src/PackageUploader.Application/Extensions/ProgramExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using PackageUploader.Application.Config;
 using PackageUploader.Application.Operations;
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.NamingConventionBinder;
@@ -57,6 +58,14 @@ internal static class ProgramExtensions
     public static T GetOptionValue<T>(this InvocationContext invocationContext, Option<T> option)
     {
         return invocationContext.ParseResult.GetValueForOption(option);
+    }
+
+    public static void AddAliasesToSwitchMappings(this Option option, Dictionary<string, string> switchMappings, string configPath)
+    {
+        foreach (var alias in option.Aliases)
+        {
+            switchMappings[alias] = configPath;
+        }
     }
 
     public static Option<T> Required<T>(this Option<T> option, bool required = true)

--- a/src/PackageUploader.Application/Operations/GetPackagesOperation.cs
+++ b/src/PackageUploader.Application/Operations/GetPackagesOperation.cs
@@ -17,68 +17,16 @@ using System.Threading.Tasks;
 
 namespace PackageUploader.Application.Operations;
 
-internal class GetPackagesOperation : Operation
+internal class GetPackagesOperation(IPackageUploaderService storeBrokerService, ILogger<GetPackagesOperation> logger, IOptions<GetPackagesOperationConfig> config, InvocationContext invocationContext) : Operation(logger)
 {
-    private readonly IPackageUploaderService _storeBrokerService;
-    private readonly ILogger<GetPackagesOperation> _logger;
-    private readonly bool _isData;
-    private readonly GetPackagesOperationConfig _config;
-    private readonly string _productIdOption;
-    private readonly string _bigIdOption;
-    private readonly string _branchFriendlyNameOption;
-    private readonly string _flightNameOption;
-    private readonly string _marketGroupNameOption;
-
-    public GetPackagesOperation(IPackageUploaderService storeBrokerService, ILogger<GetPackagesOperation> logger, IOptions<GetPackagesOperationConfig> config, InvocationContext invocationContext) : base(logger)
-    {
-        _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _isData = invocationContext.GetOptionValue(Program.DataOption);
-        _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
-        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
-        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
-        _branchFriendlyNameOption = invocationContext.GetOptionValue(Program.BranchFriendlyNameOption);
-        _flightNameOption = invocationContext.GetOptionValue(Program.FlightNameOption);
-        _marketGroupNameOption = invocationContext.GetOptionValue(Program.MarketGroupNameOption);
-
-        // arg validations
-        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
-        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
-        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
-        if (_branchFriendlyNameOption != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both BranchFriendlyName and FlightName as optional arguments");
-        if (_config.BranchFriendlyName != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both: config value branchFriendlyName, optional argument FlightName");
-        if (_config.FlightName != null && _branchFriendlyNameOption != null) throw new ArgumentException("Cannot pass both: config value flightName, optional argument BranchFriendlyName");
-    }
+    private readonly IPackageUploaderService _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
+    private readonly ILogger<GetPackagesOperation> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly bool _isData = invocationContext.GetOptionValue(Program.DataOption);
+    private readonly GetPackagesOperationConfig _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
-
-        if (_productIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (productId) with {new}", _config.ProductId, _productIdOption);
-            _config.ProductId = _productIdOption;
-        }
-        if (_bigIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (bigId) with {new}", _config.BigId, _bigIdOption);
-            _config.BigId = _bigIdOption;
-        }
-        if (_branchFriendlyNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (branchFriendlyName) with {new}", _config.BranchFriendlyName, _branchFriendlyNameOption);
-            _config.BranchFriendlyName = _branchFriendlyNameOption;
-        }
-        if (_flightNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (flightName) with {new}", _config.FlightName, _flightNameOption);
-            _config.FlightName = _flightNameOption;
-        }
-        if (_marketGroupNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (marketGroupName) with {new}", _config.MarketGroupName, _marketGroupNameOption);
-            _config.MarketGroupName = _marketGroupNameOption;
-        }
 
         var product = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
         var packageBranch = await _storeBrokerService.GetGamePackageBranch(product, _config, ct).ConfigureAwait(false);

--- a/src/PackageUploader.Application/Operations/GetProductOperation.cs
+++ b/src/PackageUploader.Application/Operations/GetProductOperation.cs
@@ -14,44 +14,16 @@ using System.Threading.Tasks;
 
 namespace PackageUploader.Application.Operations;
 
-internal class GetProductOperation : Operation
+internal class GetProductOperation(IPackageUploaderService storeBrokerService, ILogger<GetProductOperation> logger, IOptions<GetProductOperationConfig> config, InvocationContext invocationContext) : Operation(logger)
 {
-    private readonly IPackageUploaderService _storeBrokerService;
-    private readonly ILogger<GetProductOperation> _logger;
-    private readonly bool _isData;
-    private readonly GetProductOperationConfig _config;
-    private readonly string _productIdOption;
-    private readonly string _bigIdOption;
-
-    public GetProductOperation(IPackageUploaderService storeBrokerService, ILogger<GetProductOperation> logger, IOptions<GetProductOperationConfig> config, InvocationContext invocationContext) : base(logger)
-    {
-        _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _isData = invocationContext.GetOptionValue(Program.DataOption);
-        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
-        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
-        _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
-
-        // arg validations
-        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
-        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
-        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
-    }
+    private readonly IPackageUploaderService _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
+    private readonly ILogger<GetProductOperation> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly bool _isData = invocationContext.GetOptionValue(Program.DataOption);
+    private readonly GetProductOperationConfig _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
-        
-        if (_productIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (Product ID) with {new}", _config.ProductId, _productIdOption);
-            _config.ProductId = _productIdOption;
-        }
-        if (_bigIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (Big ID) with {new}", _config.BigId, _bigIdOption);
-            _config.BigId = _bigIdOption;
-        }
 
         var gameProduct = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
         var gamePackageBranches = await _storeBrokerService.GetPackageBranchesAsync(gameProduct, ct).ConfigureAwait(false);

--- a/src/PackageUploader.Application/Operations/ImportPackagesOperation.cs
+++ b/src/PackageUploader.Application/Operations/ImportPackagesOperation.cs
@@ -1,78 +1,26 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using PackageUploader.Application.Config;
 using PackageUploader.Application.Extensions;
 using PackageUploader.ClientApi;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.CommandLine.Invocation;
 
 namespace PackageUploader.Application.Operations;
 
-internal class ImportPackagesOperation : Operation
+internal class ImportPackagesOperation(IPackageUploaderService storeBrokerService, ILogger<ImportPackagesOperation> logger, IOptions<ImportPackagesOperationConfig> config) : Operation(logger)
 {
-    private readonly IPackageUploaderService _storeBrokerService;
-    private readonly ILogger<ImportPackagesOperation> _logger;
-    private readonly ImportPackagesOperationConfig _config;
-    private readonly string _productIdOption;
-    private readonly string _bigIdOption;
-    private readonly string _branchFriendlyNameOption;
-    private readonly string _flightNameOption;
-    private readonly string _marketGroupNameOption;
-
-    public ImportPackagesOperation(IPackageUploaderService storeBrokerService, ILogger<ImportPackagesOperation> logger, IOptions<ImportPackagesOperationConfig> config, InvocationContext invocationContext) : base(logger)
-    {
-        _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _config = config?.Value ?? throw new ArgumentNullException(nameof(config)); 
-        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
-        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
-        _branchFriendlyNameOption = invocationContext.GetOptionValue(Program.BranchFriendlyNameOption);
-        _flightNameOption = invocationContext.GetOptionValue(Program.FlightNameOption);
-        _marketGroupNameOption = invocationContext.GetOptionValue(Program.MarketGroupNameOption);
-
-        // arg validations
-        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
-        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
-        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
-        if (_branchFriendlyNameOption != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both BranchFriendlyName and FlightName as optional arguments");
-        if (_config.BranchFriendlyName != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both: config value branchFriendlyName, optional argument FlightName");
-        if (_config.FlightName != null && _branchFriendlyNameOption != null) throw new ArgumentException("Cannot pass both: config value flightName, optional argument BranchFriendlyName");
-    }
+    private readonly IPackageUploaderService _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
+    private readonly ILogger<ImportPackagesOperation> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ImportPackagesOperationConfig _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
-
-        if (_productIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (productId) with {new}", _config.ProductId, _productIdOption);
-            _config.ProductId = _productIdOption;
-        }
-        if (_bigIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (bigId) with {new}", _config.BigId, _bigIdOption);
-            _config.BigId = _bigIdOption;
-        }
-        if (_branchFriendlyNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (branchFriendlyName) with {new}", _config.BranchFriendlyName, _branchFriendlyNameOption);
-            _config.BranchFriendlyName = _branchFriendlyNameOption;
-        }
-        if (_flightNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (flightName) with {new}", _config.FlightName, _flightNameOption);
-            _config.FlightName = _flightNameOption;
-        }
-        if (_marketGroupNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (marketGroupName) with {new}", _config.MarketGroupName, _marketGroupNameOption);
-            _config.MarketGroupName = _marketGroupNameOption;
-        }
 
         var product = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
         var originPackageBranch = await _storeBrokerService.GetGamePackageBranch(product, _config, ct).ConfigureAwait(false);

--- a/src/PackageUploader.Application/Operations/Operation.cs
+++ b/src/PackageUploader.Application/Operations/Operation.cs
@@ -8,14 +8,9 @@ using System.Threading.Tasks;
 
 namespace PackageUploader.Application.Operations;
 
-internal abstract class Operation
+internal abstract class Operation(ILogger logger)
 {
-    private readonly ILogger _logger;
-
-    protected Operation(ILogger logger)
-    {
-        _logger = logger;
-    }
+    private readonly ILogger _logger = logger;
 
     public async Task<int> RunAsync(CancellationToken ct)
     {

--- a/src/PackageUploader.Application/Operations/PublishPackagesOperation.cs
+++ b/src/PackageUploader.Application/Operations/PublishPackagesOperation.cs
@@ -1,80 +1,28 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using PackageUploader.Application.Config;
 using PackageUploader.Application.Extensions;
 using PackageUploader.ClientApi;
 using PackageUploader.ClientApi.Client.Ingestion.Models;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.CommandLine.Invocation;
 
 namespace PackageUploader.Application.Operations;
 
-internal sealed class PublishPackagesOperation : Operation
+internal sealed class PublishPackagesOperation(IPackageUploaderService storeBrokerService, ILogger<PublishPackagesOperation> logger, IOptions<PublishPackagesOperationConfig> config) : Operation(logger)
 {
-    private readonly IPackageUploaderService _storeBrokerService;
-    private readonly ILogger<PublishPackagesOperation> _logger;
-    private readonly PublishPackagesOperationConfig _config;
-    private readonly string _productIdOption;
-    private readonly string _bigIdOption;
-    private readonly string _branchFriendlyNameOption;
-    private readonly string _flightNameOption;
-    private readonly string _destinationSandboxName;
-
-    public PublishPackagesOperation(IPackageUploaderService storeBrokerService, ILogger<PublishPackagesOperation> logger, IOptions<PublishPackagesOperationConfig> config, InvocationContext invocationContext) : base(logger)
-    {
-        _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
-        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
-        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
-        _branchFriendlyNameOption = invocationContext.GetOptionValue(Program.BranchFriendlyNameOption);
-        _flightNameOption = invocationContext.GetOptionValue(Program.FlightNameOption);
-        _destinationSandboxName = invocationContext.GetOptionValue(Program.DestinationSandboxName);
-
-        // arg validations
-        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
-        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
-        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
-        if (_branchFriendlyNameOption != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both BranchFriendlyName and FlightName as optional arguments");
-        if (_destinationSandboxName != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both DestinationSandboxName and FlightName as optional arguments");
-        if ((_config.BranchFriendlyName != null && _config.DestinationSandboxName != null) && _flightNameOption != null) throw new ArgumentException("Cannot pass both: (config values branchFriendlyName and destinationSandboxName), optional argument FlightName");
-        if (_config.FlightName != null && (_branchFriendlyNameOption != null && _destinationSandboxName != null)) throw new ArgumentException("Cannot pass both: config value flightName, (optional argument BranchFriendlyName and DestinationSandboxName)");
-    }
+    private readonly IPackageUploaderService _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
+    private readonly ILogger<PublishPackagesOperation> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly PublishPackagesOperationConfig _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
-
-        if (_productIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (productId) with {new}", _config.ProductId, _productIdOption);
-            _config.ProductId = _productIdOption;
-        }
-        if (_bigIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (bigId) with {new}", _config.BigId, _bigIdOption);
-            _config.BigId = _bigIdOption;
-        }
-        if (_branchFriendlyNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (branchFriendlyName) with {new}", _config.BranchFriendlyName, _branchFriendlyNameOption);
-            _config.BranchFriendlyName = _branchFriendlyNameOption;
-        }
-        if (_flightNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (flightName) with {new}", _config.FlightName, _flightNameOption);
-            _config.FlightName = _flightNameOption;
-        }
-        if (_destinationSandboxName != null) {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (destinationSandboxName) with {new}", _config.DestinationSandboxName, _destinationSandboxName);
-            _config.DestinationSandboxName = _destinationSandboxName;
-        }
 
         var product = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
 

--- a/src/PackageUploader.Application/Operations/RemovePackagesOperation.cs
+++ b/src/PackageUploader.Application/Operations/RemovePackagesOperation.cs
@@ -1,78 +1,26 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using PackageUploader.Application.Config;
 using PackageUploader.Application.Extensions;
 using PackageUploader.ClientApi;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.CommandLine.Invocation;
 
 namespace PackageUploader.Application.Operations;
 
-internal class RemovePackagesOperation : Operation
+internal class RemovePackagesOperation(IPackageUploaderService storeBrokerService, ILogger<RemovePackagesOperation> logger, IOptions<RemovePackagesOperationConfig> config) : Operation(logger)
 {
-    private readonly IPackageUploaderService _storeBrokerService;
-    private readonly ILogger<RemovePackagesOperation> _logger;
-    private readonly RemovePackagesOperationConfig _config;
-    private readonly string _productIdOption;
-    private readonly string _bigIdOption;
-    private readonly string _branchFriendlyNameOption;
-    private readonly string _flightNameOption;
-    private readonly string _marketGroupNameOption;
-
-    public RemovePackagesOperation(IPackageUploaderService storeBrokerService, ILogger<RemovePackagesOperation> logger, IOptions<RemovePackagesOperationConfig> config, InvocationContext invocationContext) : base(logger)
-    {
-        _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
-        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
-        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
-        _branchFriendlyNameOption = invocationContext.GetOptionValue(Program.BranchFriendlyNameOption);
-        _flightNameOption = invocationContext.GetOptionValue(Program.FlightNameOption);
-        _marketGroupNameOption = invocationContext.GetOptionValue(Program.MarketGroupNameOption);
-
-        // arg validations
-        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
-        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
-        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
-        if (_branchFriendlyNameOption != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both BranchFriendlyName and FlightName as optional arguments");
-        if (_config.BranchFriendlyName != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both: config value branchFriendlyName, optional argument FlightName");
-        if (_config.FlightName != null && _branchFriendlyNameOption != null) throw new ArgumentException("Cannot pass both: config value flightName, optional argument BranchFriendlyName");
-    }
+    private readonly IPackageUploaderService _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
+    private readonly ILogger<RemovePackagesOperation> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly RemovePackagesOperationConfig _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
-
-        if (_productIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (productId) with {new}", _config.ProductId, _productIdOption);
-            _config.ProductId = _productIdOption;
-        }
-        if (_bigIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (bigId) with {new}", _config.BigId, _bigIdOption);
-            _config.BigId = _bigIdOption;
-        }
-        if (_branchFriendlyNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (branchFriendlyName) with {new}", _config.BranchFriendlyName, _branchFriendlyNameOption);
-            _config.BranchFriendlyName = _branchFriendlyNameOption;
-        }
-        if (_flightNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (flightName) with {new}", _config.FlightName, _flightNameOption);
-            _config.FlightName = _flightNameOption;
-        }
-        if (_marketGroupNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (marketGroupName) with {new}", _config.MarketGroupName, _marketGroupNameOption);
-            _config.MarketGroupName = _marketGroupNameOption;
-        }
 
         var product = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
         var packageBranch = await _storeBrokerService.GetGamePackageBranch(product, _config, ct).ConfigureAwait(false);

--- a/src/PackageUploader.Application/Operations/UploadUwpPackageOperation.cs
+++ b/src/PackageUploader.Application/Operations/UploadUwpPackageOperation.cs
@@ -1,78 +1,26 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using PackageUploader.Application.Config;
 using PackageUploader.Application.Extensions;
 using PackageUploader.ClientApi;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.CommandLine.Invocation;
 
 namespace PackageUploader.Application.Operations;
 
-internal class UploadUwpPackageOperation : Operation
+internal class UploadUwpPackageOperation(IPackageUploaderService storeBrokerService, ILogger<UploadUwpPackageOperation> logger, IOptions<UploadUwpPackageOperationConfig> config) : Operation(logger)
 {
-    private readonly IPackageUploaderService _storeBrokerService;
-    private readonly ILogger<UploadUwpPackageOperation> _logger;
-    private readonly UploadUwpPackageOperationConfig _config;
-    private readonly string _productIdOption;
-    private readonly string _bigIdOption;
-    private readonly string _branchFriendlyNameOption;
-    private readonly string _flightNameOption;
-    private readonly string _marketGroupNameOption;
-
-    public UploadUwpPackageOperation(IPackageUploaderService storeBrokerService, ILogger<UploadUwpPackageOperation> logger, IOptions<UploadUwpPackageOperationConfig> config, InvocationContext invocationContext) : base(logger)
-    {
-        _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
-        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
-        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
-        _branchFriendlyNameOption = invocationContext.GetOptionValue(Program.BranchFriendlyNameOption);
-        _flightNameOption = invocationContext.GetOptionValue(Program.FlightNameOption);
-        _marketGroupNameOption = invocationContext.GetOptionValue(Program.MarketGroupNameOption);
-
-        // arg validations
-        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
-        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
-        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
-        if (_branchFriendlyNameOption != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both BranchFriendlyName and FlightName as optional arguments");
-        if (_config.BranchFriendlyName != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both: config value branchFriendlyName, optional argument FlightName");
-        if (_config.FlightName != null && _branchFriendlyNameOption != null) throw new ArgumentException("Cannot pass both: config value flightName, optional argument BranchFriendlyName");
-    }
+    private readonly IPackageUploaderService _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
+    private readonly ILogger<UploadUwpPackageOperation> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly UploadUwpPackageOperationConfig _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
-
-        if (_productIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (productId) with {new}", _config.ProductId, _productIdOption);
-            _config.ProductId = _productIdOption;
-        }
-        if (_bigIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (bigId) with {new}", _config.BigId, _bigIdOption);
-            _config.BigId = _bigIdOption;
-        }
-        if (_branchFriendlyNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (branchFriendlyName) with {new}", _config.BranchFriendlyName, _branchFriendlyNameOption);
-            _config.BranchFriendlyName = _branchFriendlyNameOption;
-        }
-        if (_flightNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (flightName) with {new}", _config.FlightName, _flightNameOption);
-            _config.FlightName = _flightNameOption;
-        }
-        if (_marketGroupNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (marketGroupName) with {new}", _config.MarketGroupName, _marketGroupNameOption);
-            _config.MarketGroupName = _marketGroupNameOption;
-        }
 
         var product = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
         var packageBranch = await _storeBrokerService.GetGamePackageBranch(product, _config, ct).ConfigureAwait(false);

--- a/src/PackageUploader.Application/Operations/UploadXvcPackageOperation.cs
+++ b/src/PackageUploader.Application/Operations/UploadXvcPackageOperation.cs
@@ -1,78 +1,26 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using PackageUploader.Application.Config;
 using PackageUploader.Application.Extensions;
 using PackageUploader.ClientApi;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.CommandLine.Invocation;
 
 namespace PackageUploader.Application.Operations;
 
-internal class UploadXvcPackageOperation : Operation
+internal class UploadXvcPackageOperation(IPackageUploaderService storeBrokerService, ILogger<UploadXvcPackageOperation> logger, IOptions<UploadXvcPackageOperationConfig> config) : Operation(logger)
 {
-    private readonly IPackageUploaderService _storeBrokerService;
-    private readonly ILogger<UploadXvcPackageOperation> _logger;
-    private readonly UploadXvcPackageOperationConfig _config;
-    private readonly string _productIdOption;
-    private readonly string _bigIdOption;
-    private readonly string _branchFriendlyNameOption;
-    private readonly string _flightNameOption;
-    private readonly string _marketGroupNameOption;
-
-    public UploadXvcPackageOperation(IPackageUploaderService storeBrokerService, ILogger<UploadXvcPackageOperation> logger, IOptions<UploadXvcPackageOperationConfig> config, InvocationContext invocationContext) : base(logger)
-    {
-        _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
-        _productIdOption = invocationContext.GetOptionValue(Program.ProductIdOption);
-        _bigIdOption = invocationContext.GetOptionValue(Program.BigIdOption);
-        _branchFriendlyNameOption = invocationContext.GetOptionValue(Program.BranchFriendlyNameOption);
-        _flightNameOption = invocationContext.GetOptionValue(Program.FlightNameOption);
-        _marketGroupNameOption = invocationContext.GetOptionValue(Program.MarketGroupNameOption);
-
-        // arg validations
-        if (_productIdOption != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both BigId and ProductId as optional arguments");
-        if (_config.ProductId != null && _bigIdOption != null) throw new ArgumentException("Cannot pass both: config value productId, optional argument BigId");
-        if (_config.BigId != null && _productIdOption != null) throw new ArgumentException("Cannot pass both: config value bigId, optional argument ProductId");
-        if (_branchFriendlyNameOption != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both BranchFriendlyName and FlightName as optional arguments");
-        if (_config.BranchFriendlyName != null && _flightNameOption != null) throw new ArgumentException("Cannot pass both: config value branchFriendlyName, optional argument FlightName");
-        if (_config.FlightName != null && _branchFriendlyNameOption != null) throw new ArgumentException("Cannot pass both: config value flightName, optional argument BranchFriendlyName");
-    }
+    private readonly IPackageUploaderService _storeBrokerService = storeBrokerService ?? throw new ArgumentNullException(nameof(storeBrokerService));
+    private readonly ILogger<UploadXvcPackageOperation> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly UploadXvcPackageOperationConfig _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
 
     protected override async Task ProcessAsync(CancellationToken ct)
     {
         _logger.LogInformation("Starting {operationName} operation.", _config.GetOperationName());
-
-        if (_productIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (productId) with {new}", _config.ProductId, _productIdOption);
-            _config.ProductId = _productIdOption;
-        }
-        if (_bigIdOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (bigId) with {new}", _config.BigId, _bigIdOption);
-            _config.BigId = _bigIdOption;
-        }
-        if (_branchFriendlyNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (branchFriendlyName) with {new}", _config.BranchFriendlyName, _branchFriendlyNameOption);
-            _config.BranchFriendlyName = _branchFriendlyNameOption;
-        }
-        if (_flightNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (flightName) with {new}", _config.FlightName, _flightNameOption);
-            _config.FlightName = _flightNameOption;
-        }
-        if (_marketGroupNameOption != null)
-        {
-            _logger.LogInformation("Optional argument passed. Replacing config value {old} (marketGroupName) with {new}", _config.MarketGroupName, _marketGroupNameOption);
-            _config.MarketGroupName = _marketGroupNameOption;
-        }
 
         var product = await _storeBrokerService.GetProductAsync(_config, ct).ConfigureAwait(false);
         var packageBranch = await _storeBrokerService.GetGamePackageBranch(product, _config, ct).ConfigureAwait(false);

--- a/src/PackageUploader.Application/packages.lock.json
+++ b/src/PackageUploader.Application/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.15, )",
-        "resolved": "8.0.15",
-        "contentHash": "wMf2N7fJ846aKd73R5gqvtbyqu89/LywlWCtMyXUqKYc9DR3s9kUgNrLIsT9KeRwyinGFJDtRbiib0M4YBX6ZA=="
+        "requested": "[8.0.16, )",
+        "resolved": "8.0.16",
+        "contentHash": "AqAD0M+uylO2cUUX7i4Ox520hOODYTldiy8AHFsEtW6a9jmJUgtwJA7vaS7x55AqUpMbi7a9qzrzwbDRl70GNQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Direct",
@@ -71,9 +71,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.15, )",
-        "resolved": "8.0.15",
-        "contentHash": "s4eXlcRGyHeCgFUGQnhq0e/SCHBPp0jOHgMqZg3fQ2OCHJSm1aOUhI6RFWuVIcEb9ig2WgI2kWukk8wu72EbUQ=="
+        "requested": "[8.0.16, )",
+        "resolved": "8.0.16",
+        "contentHash": "0H1QaKpVibe++Zx6EYJQGhrpfz2bBPGiQ7Rpsmx8I3+oKv+ZRRIfVfmcj50KuZlhhRE6V02y5bUjP+V2oPM2ng=="
       },
       "System.CommandLine.Hosting": {
         "type": "Direct",
@@ -530,17 +530,17 @@
     "net8.0/linux-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.15, )",
-        "resolved": "8.0.15",
-        "contentHash": "wMf2N7fJ846aKd73R5gqvtbyqu89/LywlWCtMyXUqKYc9DR3s9kUgNrLIsT9KeRwyinGFJDtRbiib0M4YBX6ZA==",
+        "requested": "[8.0.16, )",
+        "resolved": "8.0.16",
+        "contentHash": "AqAD0M+uylO2cUUX7i4Ox520hOODYTldiy8AHFsEtW6a9jmJUgtwJA7vaS7x55AqUpMbi7a9qzrzwbDRl70GNQ==",
         "dependencies": {
-          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "8.0.15"
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "8.0.16"
         }
       },
       "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "8.0.15",
-        "contentHash": "cd6zPkPgS2OZflyVM3n4UR3YowbTDCIAQHI+tHMUHITa6XTTzyrWiqmvo42Oh7NPu04C7SKqEiT2WbdajYoi/w=="
+        "resolved": "8.0.16",
+        "contentHash": "k3JJhz52hMDScrDPZem4QcwDbYLpUQ1Va3eCbcpx+1nLj1h9L6mjkSM8ptZV8NVSgarrioju4dGR8NI+dqj9Gg=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -564,17 +564,17 @@
     "net8.0/win-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.15, )",
-        "resolved": "8.0.15",
-        "contentHash": "wMf2N7fJ846aKd73R5gqvtbyqu89/LywlWCtMyXUqKYc9DR3s9kUgNrLIsT9KeRwyinGFJDtRbiib0M4YBX6ZA==",
+        "requested": "[8.0.16, )",
+        "resolved": "8.0.16",
+        "contentHash": "AqAD0M+uylO2cUUX7i4Ox520hOODYTldiy8AHFsEtW6a9jmJUgtwJA7vaS7x55AqUpMbi7a9qzrzwbDRl70GNQ==",
         "dependencies": {
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "8.0.15"
+          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "8.0.16"
         }
       },
       "runtime.win-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "8.0.15",
-        "contentHash": "WTC2bvstnJztrKdeF+ILz5cEe3C8gpoft5BRmquaEfvTDT+N/YrqzLLXLKUmtQb5w1M4i8tYGHg2rOqJ0UsPrA=="
+        "resolved": "8.0.16",
+        "contentHash": "BxsgWbjf+qy+8fCUqkc3i9ZChQjVLsWZqPezjWUjvLfzh/qFzj3YtB0HJWlOw428UFvULX5o9lZ/OkI+uHNxcQ=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",

--- a/src/PackageUploader.ClientApi/packages.lock.json
+++ b/src/PackageUploader.ClientApi/packages.lock.json
@@ -97,9 +97,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.15, )",
-        "resolved": "8.0.15",
-        "contentHash": "s4eXlcRGyHeCgFUGQnhq0e/SCHBPp0jOHgMqZg3fQ2OCHJSm1aOUhI6RFWuVIcEb9ig2WgI2kWukk8wu72EbUQ=="
+        "requested": "[8.0.16, )",
+        "resolved": "8.0.16",
+        "contentHash": "0H1QaKpVibe++Zx6EYJQGhrpfz2bBPGiQ7Rpsmx8I3+oKv+ZRRIfVfmcj50KuZlhhRE6V02y5bUjP+V2oPM2ng=="
       },
       "Polly.Contrib.WaitAndRetry": {
         "type": "Direct",

--- a/src/PackageUploader.FileLogger/packages.lock.json
+++ b/src/PackageUploader.FileLogger/packages.lock.json
@@ -31,9 +31,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.15, )",
-        "resolved": "8.0.15",
-        "contentHash": "s4eXlcRGyHeCgFUGQnhq0e/SCHBPp0jOHgMqZg3fQ2OCHJSm1aOUhI6RFWuVIcEb9ig2WgI2kWukk8wu72EbUQ=="
+        "requested": "[8.0.16, )",
+        "resolved": "8.0.16",
+        "contentHash": "0H1QaKpVibe++Zx6EYJQGhrpfz2bBPGiQ7Rpsmx8I3+oKv+ZRRIfVfmcj50KuZlhhRE6V02y5bUjP+V2oPM2ng=="
       },
       "System.Text.Json": {
         "type": "Direct",


### PR DESCRIPTION
Previous change added command line arguments by changing all operations, this could be simplified by using a command line switch mapping. Reducing the needed code and simplifying the logic.