### PR TITLE
Add comment to suppress CodeQL issue.

### DIFF
--- a/src/PackageUploader.ClientApi/Client/Ingestion/TokenProvider/DefaultAzureCredentialAccessTokenProvider.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/TokenProvider/DefaultAzureCredentialAccessTokenProvider.cs
@@ -19,7 +19,7 @@ public class DefaultAzureCredentialAccessTokenProvider : CredentialAccessTokenPr
     public async Task<IngestionAccessToken> GetTokenAsync(CancellationToken ct)
     {
         var azureCredentialOptions = SetTokenCredentialOptions(new DefaultAzureCredentialOptions());
-        var azureCredential = new DefaultAzureCredential(azureCredentialOptions);
+        var azureCredential = new DefaultAzureCredential(azureCredentialOptions);   // CodeQL [SM05137] Intentially using default Azure credentials as provider implementation.
 
         return await GetIngestionAccessTokenAsync(azureCredential, ct).ConfigureAwait(false);
     }


### PR DESCRIPTION
CodeQL flagged use of `DefaultAzureCredential`. However, in this case the provider implementation must use it.