### PR TITLE
Add functionality to automatically update SubVal if MakePkg.exe is new enough

### DIFF
--- a/src/PackageUploader.Application/packages.lock.json
+++ b/src/PackageUploader.Application/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.12, )",
-        "resolved": "8.0.12",
-        "contentHash": "zhXnz2574mBc/ocGoG+qB0BgyoK9bH7f7Te1fNQJGbpwLLwZO5KKaTBmfM8N8THb3a2vQVFonbBzQ//d15TmQQ=="
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "09sjUN6lE2os7s3qZDKsZQvng84wquilKCMY+cWD993evNSW9kII9Gm6j+xI0bT/x0CNDdhkHDyAbB47ObF8Bw=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Direct",
@@ -72,9 +72,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "System.CommandLine.Hosting": {
         "type": "Direct",
@@ -536,17 +536,17 @@
     "net8.0/linux-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.12, )",
-        "resolved": "8.0.12",
-        "contentHash": "zhXnz2574mBc/ocGoG+qB0BgyoK9bH7f7Te1fNQJGbpwLLwZO5KKaTBmfM8N8THb3a2vQVFonbBzQ//d15TmQQ==",
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "09sjUN6lE2os7s3qZDKsZQvng84wquilKCMY+cWD993evNSW9kII9Gm6j+xI0bT/x0CNDdhkHDyAbB47ObF8Bw==",
         "dependencies": {
-          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "8.0.12"
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "8.0.17"
         }
       },
       "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "8.0.12",
-        "contentHash": "6dbW/3tIwfSZ514tfl55XamfvamLm3nIj8DohNvWTLNnkHOqQ6Gshywc8v/zxtCjnv1zp5V0e7TRB9H1/arU/Q=="
+        "resolved": "8.0.17",
+        "contentHash": "agBzgKp9qjC8jem23ik2fpYbYZWroAYcG7y6SOL8wOdB2uacBS5ERLQvc0enGaRmP5mJoCLqDkq9WFWvrHDhfw=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -567,17 +567,17 @@
     "net8.0/win-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[8.0.12, )",
-        "resolved": "8.0.12",
-        "contentHash": "zhXnz2574mBc/ocGoG+qB0BgyoK9bH7f7Te1fNQJGbpwLLwZO5KKaTBmfM8N8THb3a2vQVFonbBzQ//d15TmQQ==",
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "09sjUN6lE2os7s3qZDKsZQvng84wquilKCMY+cWD993evNSW9kII9Gm6j+xI0bT/x0CNDdhkHDyAbB47ObF8Bw==",
         "dependencies": {
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "8.0.12"
+          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "8.0.17"
         }
       },
       "runtime.win-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "8.0.12",
-        "contentHash": "d+SPsKQYCePnFtsMuozwbDEslRnI01J7veRHqdbU5nXILyqv9PSuxQGzO1IDgsfuHHiPIoZoHGitmhgzVcaj+w=="
+        "resolved": "8.0.17",
+        "contentHash": "yIP2Mt0aAjyrfppVh3QQ67uFRy/G6lhcibhnunJABz3ulnOFM0U9x4V76IHf+0BrTTN/aIVw9gwUD6tbJXmJZg=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",

--- a/src/PackageUploader.ClientApi/packages.lock.json
+++ b/src/PackageUploader.ClientApi/packages.lock.json
@@ -99,9 +99,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "Polly.Contrib.WaitAndRetry": {
         "type": "Direct",

--- a/src/PackageUploader.FileLogger/packages.lock.json
+++ b/src/PackageUploader.FileLogger/packages.lock.json
@@ -31,9 +31,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.17, )",
-        "resolved": "8.0.17",
-        "contentHash": "x5/y4l8AtshpBOrCZdlE4txw8K3e3s9meBFeZeR3l8hbbku2V7kK6ojhXvrbjg1rk3G+JqL1BI26gtgc1ZrdUw=="
+        "requested": "[8.0.18, )",
+        "resolved": "8.0.18",
+        "contentHash": "OiXqr2YIBEV9dsAWEtasK470ALyJ0VxJ9k4MotOxlWV6HeEgrJKYMW4HHj1OCCXvqE0/A25wEKPkpfiBARgDZA=="
       },
       "System.Text.Json": {
         "type": "Direct",

--- a/src/PackageUploader.UI/Providers/PathConfigurationProvider.cs
+++ b/src/PackageUploader.UI/Providers/PathConfigurationProvider.cs
@@ -22,6 +22,20 @@ public partial class PathConfigurationProvider : INotifyPropertyChanged
         }
     }
 
+    private string _baseSubValPath = string.Empty;
+    public string BaseSubValPath
+    {
+        get => _baseSubValPath;
+        set
+        {
+            if (_baseSubValPath != value)
+            {
+                _baseSubValPath = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
     private string _packageUploaderPath = string.Empty;
     public string PackageUploaderPath
     {

--- a/src/PackageUploader.UI/View/PackagingFinishedView.xaml
+++ b/src/PackageUploader.UI/View/PackagingFinishedView.xaml
@@ -120,7 +120,7 @@
                         Margin="0, 0, 10, 0"/>
             </Grid>
         </Border>
-        <Border Grid.Row="3" Visibility="{Binding ValidatorFailuresExist}"
+        <Border Grid.Row="3" Visibility="{Binding ValidatorFailuresExist, Converter={StaticResource BooleanToVisibilityConverter}}"
                 Background="{DynamicResource ErrorRedTransluscentBrush}"
                 Margin="100, 10, 100, 0"
                 CornerRadius="6"

--- a/src/PackageUploader.UI/ViewModel/BaseViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/BaseViewModel.cs
@@ -10,7 +10,7 @@ namespace PackageUploader.UI.ViewModel;
 
 public partial class BaseViewModel : INotifyPropertyChanged
 {
-    private static readonly string _settingsFolder = Path.Combine(
+    protected static readonly string _settingsFolder = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
         "XboxPackageTool");
     


### PR DESCRIPTION
SubmissionValidator.dll is copied from the GDK directory into the application's storage in order to ensure we have write-access to replace it. The appropriate flag is then passed to MakePkg.exe at packaging time.

New tests were added to validate the flag logic as well as manual validation with an internal version of MakePkg.exe which supports this upcoming flag (April 2025 GDK Update 2 and October 2025 GDK).