### PR TITLE
Enable CFG for extra security

### DIFF
--- a/src/PackageUploader.Application/PackageUploader.Application.csproj
+++ b/src/PackageUploader.Application/PackageUploader.Application.csproj
@@ -14,6 +14,7 @@
     
     <!-- Security settings -->
     <HighEntropyVA>true</HighEntropyVA>
+    <EnableControlFlowGuard>true</EnableControlFlowGuard>
     
     <!-- Test settings -->
     <InternalsVisibleTo>PackageUploader.Application.Test</InternalsVisibleTo>


### PR DESCRIPTION
Microsoft security policy indicates we should use ControlFlowGuard when compiling binaries which have a native component, which this one does.