### PR TITLE
Ensure we always log the version for easier debugging

### DIFF
--- a/src/PackageUploader.Application/Extensions/ProgramExtensions.cs
+++ b/src/PackageUploader.Application/Extensions/ProgramExtensions.cs
@@ -32,7 +32,7 @@ internal static class ProgramExtensions
         try
         {
             var version = GetVersion();
-            logger.LogDebug("PackageUploader v.{version} is starting.", version);
+            logger.LogInformation("PackageUploader v.{version} is starting.", version);
             return await host.Services.GetRequiredService<T>().RunAsync(ct).ConfigureAwait(false);
         }
         catch (Exception e)


### PR DESCRIPTION
I noticed we only log this in Verbose mode, but the first question I always want to know is 'what version are we running', so this should always be logged.