### PR TITLE
Add MSIXVC2 packaging toggle to "Make a game package"

### DIFF
--- a/src/PackageUploader.UI/Providers/PackingProgressPercentageProvider.cs
+++ b/src/PackageUploader.UI/Providers/PackingProgressPercentageProvider.cs
@@ -30,10 +30,22 @@ namespace PackageUploader.UI.Providers
             }
         }
 
+        private bool _isIndeterminate;
+        public bool IsIndeterminate
+        {
+            get => _isIndeterminate;
+            set
+            {
+                _isIndeterminate = value;
+                OnPropertyChanged(nameof(IsIndeterminate));
+            }
+        }
+
         public PackingProgressPercentageProvider()
         {
             _packingProgressPercentage = 0;
             _packingCancelled = false;
+            _isIndeterminate = false;
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/PackageUploader.UI/Providers/PackingProgressPercentageProvider.cs
+++ b/src/PackageUploader.UI/Providers/PackingProgressPercentageProvider.cs
@@ -30,14 +30,14 @@ namespace PackageUploader.UI.Providers
             }
         }
 
-        private bool _isIndeterminate;
-        public bool IsIndeterminate
+        private bool _isMsixvc2;
+        public bool IsMsixvc2
         {
-            get => _isIndeterminate;
+            get => _isMsixvc2;
             set
             {
-                _isIndeterminate = value;
-                OnPropertyChanged(nameof(IsIndeterminate));
+                _isMsixvc2 = value;
+                OnPropertyChanged(nameof(IsMsixvc2));
             }
         }
 
@@ -45,7 +45,7 @@ namespace PackageUploader.UI.Providers
         {
             _packingProgressPercentage = 0;
             _packingCancelled = false;
-            _isIndeterminate = false;
+            _isMsixvc2 = false;
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/PackageUploader.UI/Resources/Strings/PackageCreation.Designer.cs
+++ b/src/PackageUploader.UI/Resources/Strings/PackageCreation.Designer.cs
@@ -419,5 +419,14 @@ namespace PackageUploader.UI.Resources.Strings {
                 return ResourceManager.GetString("ValidatorPathTitleText", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package as MSIXVC2 (.msixvc).
+        /// </summary>
+        public static string UseMsixvc2Text {
+            get {
+                return ResourceManager.GetString("UseMsixvc2Text", resourceCulture);
+            }
+        }
     }
 }

--- a/src/PackageUploader.UI/Resources/Strings/PackageCreation.resx
+++ b/src/PackageUploader.UI/Resources/Strings/PackageCreation.resx
@@ -237,4 +237,7 @@
   <data name="ValidatorPathTitleText" xml:space="preserve">
     <value>Folder path for SubmissionValidator.dll</value>
   </data>
+  <data name="UseMsixvc2Text" xml:space="preserve">
+    <value>Package as MSIXVC2 (.msixvc)</value>
+  </data>
 </root>

--- a/src/PackageUploader.UI/Resources/Strings/PackagingProgress.Designer.cs
+++ b/src/PackageUploader.UI/Resources/Strings/PackagingProgress.Designer.cs
@@ -106,6 +106,15 @@ namespace PackageUploader.UI.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Packaging using MSIXVC2....
+        /// </summary>
+        public static string PackingMsixvc2Text {
+            get {
+                return ResourceManager.GetString("PackingMsixvc2Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Validating files....
         /// </summary>
         public static string ValidatingFilesText {

--- a/src/PackageUploader.UI/Resources/Strings/PackagingProgress.Designer.cs
+++ b/src/PackageUploader.UI/Resources/Strings/PackagingProgress.Designer.cs
@@ -19,7 +19,7 @@ namespace PackageUploader.UI.Resources.Strings {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class PackagingProgress {
@@ -79,11 +79,29 @@ namespace PackageUploader.UI.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Packaging data....
+        /// </summary>
+        public static string PackagingDataText {
+            get {
+                return ResourceManager.GetString("PackagingDataText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Getting your package ready....
         /// </summary>
         public static string PackagingProgressTitleText {
             get {
                 return ResourceManager.GetString("PackagingProgressTitleText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Packaging using MSIXVC2....
+        /// </summary>
+        public static string PackingMsixvc2Text {
+            get {
+                return ResourceManager.GetString("PackingMsixvc2Text", resourceCulture);
             }
         }
         
@@ -106,15 +124,6 @@ namespace PackageUploader.UI.Resources.Strings {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Packaging using MSIXVC2....
-        /// </summary>
-        public static string PackingMsixvc2Text {
-            get {
-                return ResourceManager.GetString("PackingMsixvc2Text", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Validating files....
         /// </summary>
         public static string ValidatingFilesText {
@@ -129,15 +138,6 @@ namespace PackageUploader.UI.Resources.Strings {
         public static string VerifyingPackageContentsText {
             get {
                 return ResourceManager.GetString("VerifyingPackageContentsText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Packaging data....
-        /// </summary>
-        public static string PackagingDataText {
-            get {
-                return ResourceManager.GetString("PackagingDataText", resourceCulture);
             }
         }
     }

--- a/src/PackageUploader.UI/Resources/Strings/PackagingProgress.Designer.cs
+++ b/src/PackageUploader.UI/Resources/Strings/PackagingProgress.Designer.cs
@@ -131,5 +131,14 @@ namespace PackageUploader.UI.Resources.Strings {
                 return ResourceManager.GetString("VerifyingPackageContentsText", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Packaging data....
+        /// </summary>
+        public static string PackagingDataText {
+            get {
+                return ResourceManager.GetString("PackagingDataText", resourceCulture);
+            }
+        }
     }
 }

--- a/src/PackageUploader.UI/Resources/Strings/PackagingProgress.resx
+++ b/src/PackageUploader.UI/Resources/Strings/PackagingProgress.resx
@@ -138,4 +138,7 @@
   <data name="VerifyingPackageContentsText" xml:space="preserve">
     <value>Verifying package contents...</value>
   </data>
+  <data name="PackingMsixvc2Text" xml:space="preserve">
+    <value>Packaging using MSIXVC2...</value>
+  </data>
 </root>

--- a/src/PackageUploader.UI/Resources/Strings/PackagingProgress.resx
+++ b/src/PackageUploader.UI/Resources/Strings/PackagingProgress.resx
@@ -141,4 +141,7 @@
   <data name="PackingMsixvc2Text" xml:space="preserve">
     <value>Packaging using MSIXVC2...</value>
   </data>
+  <data name="PackagingDataText" xml:space="preserve">
+    <value>Packaging data...</value>
+  </data>
 </root>

--- a/src/PackageUploader.UI/View/PackageCreationView.xaml
+++ b/src/PackageUploader.UI/View/PackageCreationView.xaml
@@ -406,6 +406,7 @@
                             <RowDefinition />
                             <RowDefinition />
                             <RowDefinition />
+                            <RowDefinition />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -506,6 +507,16 @@
                                        HorizontalAlignment="Left"
                                        TextWrapping="Wrap"/>
                         </StackPanel>
+
+                        <CheckBox Grid.Row="5" Grid.Column="0"
+                                  Content="{x:Static strings:PackageCreation.UseMsixvc2Text}"
+                                  d:Content="Package as MSIXVC2 (.msixvc)"
+                                  IsChecked="{Binding UseMsixvc2}"
+                                  Visibility="{Binding IsMakePkg2Available, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                  Foreground="{DynamicResource PrimaryTextBrush}"
+                                  HorizontalAlignment="Left"
+                                  VerticalContentAlignment="Center"
+                                  Margin="0,10,0,0"/>
                     </Grid>
                 </StackPanel>
                 <Rectangle Grid.Column="2" Grid.RowSpan="2" Width="1" Fill="{DynamicResource BorderBrush}" Margin="10,0" />

--- a/src/PackageUploader.UI/View/PackagingProgressView.xaml
+++ b/src/PackageUploader.UI/View/PackagingProgressView.xaml
@@ -72,7 +72,8 @@
                 <StackPanel Grid.Row="0"
                             Grid.Column="1"
                             Orientation="Horizontal"
-                            HorizontalAlignment="Right">
+                            HorizontalAlignment="Right"
+                            Margin="5, 0, 0, 0">
                     <TextBlock Text="{Binding PackingProgressPercentage, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}"
                                Foreground="{DynamicResource PrimaryTextBrush}"/>
                     <TextBlock Text="{x:Static strings:PackagingProgress.PercentComplete}"

--- a/src/PackageUploader.UI/View/PackagingProgressView.xaml
+++ b/src/PackageUploader.UI/View/PackagingProgressView.xaml
@@ -60,7 +60,7 @@
                            Text="{x:Static strings:PackagingProgress.PackingText}"
                            Foreground="{DynamicResource PrimaryTextBrush}" 
                            HorizontalAlignment="Left"
-                           Visibility="{Binding IsIndeterminate, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter=Invert}"/>
+                           Visibility="{Binding IsMsixvc2, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter=Invert}"/>
                 <TextBlock Grid.Row="0"
                            Grid.Column="0"
                            Margin="0, 0, 0, 10"
@@ -68,12 +68,11 @@
                            Text="{x:Static strings:PackagingProgress.PackingMsixvc2Text}"
                            Foreground="{DynamicResource PrimaryTextBrush}" 
                            HorizontalAlignment="Left"
-                           Visibility="{Binding IsIndeterminate, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                           Visibility="{Binding IsMsixvc2, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                 <StackPanel Grid.Row="0"
                             Grid.Column="1"
                             Orientation="Horizontal"
-                            HorizontalAlignment="Right"
-                            Visibility="{Binding IsIndeterminate, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter=Invert}">
+                            HorizontalAlignment="Right">
                     <TextBlock Text="{Binding PackingProgressPercentage, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}"
                                Foreground="{DynamicResource PrimaryTextBrush}"/>
                     <TextBlock Text="{x:Static strings:PackagingProgress.PercentComplete}"
@@ -86,15 +85,12 @@
                              Minimum="0"
                              Maximum="100"
                              Value="{Binding PackingProgressPercentage}"
-                             IsIndeterminate="{Binding IsIndeterminate}"
                              HorizontalAlignment="Stretch"
                              VerticalAlignment="Stretch"
                              Height="3"/>
             </Grid>
-            <!-- Updating labels
-                 The entire section is collapsed when IsIndeterminate is true. -->
-            <Grid HorizontalAlignment="Center"
-                  Visibility="{Binding IsIndeterminate, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter=Invert}">
+            <!-- Updating labels -->
+            <Grid HorizontalAlignment="Center">
             <Grid.RowDefinitions>
                 <RowDefinition Height="auto"/>
                 <RowDefinition Height="auto"/>
@@ -180,7 +176,16 @@
                        Foreground="{DynamicResource PrimaryTextBrush}"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Bottom"
-                       Margin="0, 30, 0, 0"/>
+                       Margin="0, 30, 0, 0"
+                       Visibility="{Binding IsMsixvc2, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter=Invert}"/>
+            <TextBlock Grid.Row="1" Grid.Column="1"
+                       Text="{x:Static strings:PackagingProgress.PackagingDataText}"
+                       d:Text="Packaging data..."
+                       Foreground="{DynamicResource PrimaryTextBrush}"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Bottom"
+                       Margin="0, 30, 0, 0"
+                       Visibility="{Binding IsMsixvc2, Converter={StaticResource BooleanToVisibilityConverter}}"/>
             <!-- Row 3 -->
             <ContentControl Grid.Row="2"
                            Grid.Column="0"

--- a/src/PackageUploader.UI/View/PackagingProgressView.xaml
+++ b/src/PackageUploader.UI/View/PackagingProgressView.xaml
@@ -23,72 +23,78 @@
     </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
-            <!-- picture -->
-            <RowDefinition Height="Auto"/>
-            <!-- heading -->
-            <RowDefinition Height="Auto"/>
-            <!-- progress bars bundle-->
-            <RowDefinition Height="Auto"/>
-            <!-- updating labels -->
-            <RowDefinition Height="Auto"/>
-            <!-- cancel button? -->
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <Image Grid.Row="0"
-               Margin="{DynamicResource ProgressImageMargin}"
-               Source="/Resources/Images/InProgress.png"
-               HorizontalAlignment="Center"
-               VerticalAlignment="Center"
-               Height="{DynamicResource StatusImageSize}"
-               Width="{DynamicResource StatusImageSize}"/>
-        <TextBlock Grid.Row="1"
-                   Margin="{DynamicResource ProgressHeadingMargin}"
-                   Style="{StaticResource SubHeadline}"
-                   Text="{x:Static strings:PackagingProgress.PackagingProgressTitleText}"
-                   d:Text="Getting your package ready..."
-                   Foreground="{DynamicResource PrimaryTextBrush}" />
-        <!-- Loading Bar -->
-        <Grid Grid.Row="2"
-              Margin="{DynamicResource ProgressSectionMargin}"
-              MaxWidth="{DynamicResource ProgressBarMaxWidth}"
-              HorizontalAlignment="Center">
-            <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
-            <TextBlock Grid.Row="0"
-                       Grid.Column="0"
-                       Margin="0, 0, 0, 10"
-                       d:Text="Packaging..."
-                       Text="{x:Static strings:PackagingProgress.PackingText}"
-                       Foreground="{DynamicResource PrimaryTextBrush}" 
-                       HorizontalAlignment="Left"/>
-            <StackPanel Grid.Row="0"
-                        Grid.Column="1"
-                        Orientation="Horizontal"
-                        HorizontalAlignment="Right">
-                <TextBlock Text="{Binding PackingProgressPercentage, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}"
-                           Foreground="{DynamicResource PrimaryTextBrush}"/>
-                <TextBlock Text="{x:Static strings:PackagingProgress.PercentComplete}"
-                           d:Text="% complete"
-                           Foreground="{DynamicResource PrimaryTextBrush}" />
-            </StackPanel>
-            <ProgressBar Grid.Row="1"
-                         Grid.ColumnSpan="2"
-                         Margin="0, 0, 0, 23"
-                         Minimum="0"
-                         Maximum="100"
-                         Value="{Binding PackingProgressPercentage}"
-                         HorizontalAlignment="Stretch"
-                         VerticalAlignment="Stretch"
-                         Height="3"/>
-        </Grid>
-        <!-- updating labels -->
-        <Grid Grid.Row="3" HorizontalAlignment="Center">
+        <StackPanel Grid.Row="0"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+            <Image Margin="{DynamicResource ProgressImageMargin}"
+                   Source="/Resources/Images/InProgress.png"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Height="{DynamicResource StatusImageSize}"
+                   Width="{DynamicResource StatusImageSize}"/>
+            <TextBlock Margin="{DynamicResource ProgressHeadingMargin}"
+                       Style="{StaticResource SubHeadline}"
+                       Text="{x:Static strings:PackagingProgress.PackagingProgressTitleText}"
+                       d:Text="Getting your package ready..."
+                       HorizontalAlignment="Center"
+                       Foreground="{DynamicResource PrimaryTextBrush}" />
+            <!-- Loading Bar -->
+            <Grid Margin="{DynamicResource ProgressSectionMargin}"
+                  MaxWidth="{DynamicResource ProgressBarMaxWidth}"
+                  HorizontalAlignment="Center">
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Row="0"
+                           Grid.Column="0"
+                           Margin="0, 0, 0, 10"
+                           d:Text="Packaging..."
+                           Text="{x:Static strings:PackagingProgress.PackingText}"
+                           Foreground="{DynamicResource PrimaryTextBrush}" 
+                           HorizontalAlignment="Left"
+                           Visibility="{Binding IsIndeterminate, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter=Invert}"/>
+                <TextBlock Grid.Row="0"
+                           Grid.Column="0"
+                           Margin="0, 0, 0, 10"
+                           d:Text="Packaging using MSIXVC2..."
+                           Text="{x:Static strings:PackagingProgress.PackingMsixvc2Text}"
+                           Foreground="{DynamicResource PrimaryTextBrush}" 
+                           HorizontalAlignment="Left"
+                           Visibility="{Binding IsIndeterminate, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                <StackPanel Grid.Row="0"
+                            Grid.Column="1"
+                            Orientation="Horizontal"
+                            HorizontalAlignment="Right"
+                            Visibility="{Binding IsIndeterminate, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter=Invert}">
+                    <TextBlock Text="{Binding PackingProgressPercentage, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}"
+                               Foreground="{DynamicResource PrimaryTextBrush}"/>
+                    <TextBlock Text="{x:Static strings:PackagingProgress.PercentComplete}"
+                               d:Text="% complete"
+                               Foreground="{DynamicResource PrimaryTextBrush}" />
+                </StackPanel>
+                <ProgressBar Grid.Row="1"
+                             Grid.ColumnSpan="2"
+                             Margin="0, 0, 0, 23"
+                             Minimum="0"
+                             Maximum="100"
+                             Value="{Binding PackingProgressPercentage}"
+                             IsIndeterminate="{Binding IsIndeterminate}"
+                             HorizontalAlignment="Stretch"
+                             VerticalAlignment="Stretch"
+                             Height="3"/>
+            </Grid>
+            <!-- Updating labels
+                 The entire section is collapsed when IsIndeterminate is true. -->
+            <Grid HorizontalAlignment="Center"
+                  Visibility="{Binding IsIndeterminate, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter=Invert}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="auto"/>
                 <RowDefinition Height="auto"/>
@@ -219,8 +225,9 @@
                        HorizontalAlignment="Left"
                        VerticalAlignment="Bottom"
                        Margin="0, 30, 0, 0"/>
-        </Grid>
-        <StackPanel Grid.Row="4"
+            </Grid>
+        </StackPanel>
+        <StackPanel Grid.Row="1"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right">
             <Button Content="{x:Static strings:PackagingProgress.CancelPackagingButtonContentText}"

--- a/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
@@ -667,19 +667,32 @@ public partial class PackageCreationViewModel : BaseViewModel
             return;
         }
 
-        string cmdFormat = "pack /v /f \"{0}\" /d \"{1}\" /pd \"{2}\"";
-        string arguments = string.Format(cmdFormat, MappingDataXmlPath, GameDataPath, buildPath);
+        string arguments;
+        string executablePath;
 
-        // Populate our arguments for SubVal validation.
-        if (!PopulateSubValArgs(_settingsFolder, ref arguments))
+        if (UseMsixvc2)
         {
-            return;
+            // Argument order matches the makepkg2 script convention: /f /pd /d /msixvc2.
+            string msixvc2CmdFormat = "pack /f \"{0}\" /pd \"{1}\" /d \"{2}\" /msixvc2";
+            arguments = string.Format(msixvc2CmdFormat, MappingDataXmlPath, buildPath, GameDataPath);
+            executablePath = _pathConfigurationService.MakePkg2Path;
+        }
+        else
+        {
+            string cmdFormat = "pack /v /f \"{0}\" /d \"{1}\" /pd \"{2}\"";
+            arguments = string.Format(cmdFormat, MappingDataXmlPath, GameDataPath, buildPath);
+            executablePath = _pathConfigurationService.MakePkgPath;
+
+            if (!PopulateSubValArgs(_settingsFolder, ref arguments))
+            {
+                return;
+            }
         }
 
         SetConsoleCtrlHandler(null, false);
 
         _makePackageProcess = new Process();
-        _makePackageProcess.StartInfo.FileName = _pathConfigurationService.MakePkgPath;
+        _makePackageProcess.StartInfo.FileName = executablePath;
         _makePackageProcess.StartInfo.Arguments = arguments;
         _makePackageProcess.StartInfo.RedirectStandardOutput = true;
         _makePackageProcess.StartInfo.RedirectStandardError = true;

--- a/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
@@ -1024,6 +1024,9 @@ public partial class PackageCreationViewModel : BaseViewModel
     [GeneratedRegex(@"See the Submission Validator log file at '(?<PackagePath>.*?Validator.*?\.xml)'")]
     private static partial Regex ValidatorResultsPathRegex();
 
+    [GeneratedRegex(@"Submission Validator log path:\s*(?<PackagePath>.*?Validator.*?\.xml)")]
+    private static partial Regex ValidatorResultsPathRegex2();
+
     private void ProcessMakePackageOutput(string outputString)
     {
         // Package Path for XVC
@@ -1053,8 +1056,12 @@ public partial class PackageCreationViewModel : BaseViewModel
         }
         Package.GameConfigFilePath = Path.Combine(GameDataPath, "MicrosoftGame.config");
 
-        // Validator Results Path
+        // Validator Results Path — try legacy makepkg format first, then makepkg2 format
         MatchCollection validatorResultsPathMatchCollection = ValidatorResultsPathRegex().Matches(outputString);
+        if (validatorResultsPathMatchCollection.Count == 0)
+        {
+            validatorResultsPathMatchCollection = ValidatorResultsPathRegex2().Matches(outputString);
+        }
         for (int i = 0; i < validatorResultsPathMatchCollection.Count; i++)
         {
             string validatorResultsPathValue = validatorResultsPathMatchCollection[i].Groups["PackagePath"].Value;

--- a/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
@@ -796,6 +796,8 @@ public partial class PackageCreationViewModel : BaseViewModel
         ProgressValue = 0;
         IsCreationInProgress = true;
 
+        _packingProgressPercentageProvider.IsIndeterminate = UseMsixvc2;
+
         _logger.LogInformation("Calling '{Command}'", _makePackageProcess.StartInfo.FileName + " " + _makePackageProcess.StartInfo.Arguments);
         _makePackageProcess.Start();
         _makePackageProcess.BeginOutputReadLine();

--- a/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
@@ -673,7 +673,7 @@ public partial class PackageCreationViewModel : BaseViewModel
         if (UseMsixvc2)
         {
             // Argument order matches the makepkg2 script convention: /f /pd /d /msixvc2.
-            string msixvc2CmdFormat = "pack /f \"{0}\" /pd \"{1}\" /d \"{2}\" /msixvc2";
+            string msixvc2CmdFormat = "pack /f \"{0}\" /pd \"{1}\" /d \"{2}\" /msixvc2 /updatesubval";
             arguments = string.Format(msixvc2CmdFormat, MappingDataXmlPath, buildPath, GameDataPath);
             executablePath = _pathConfigurationService.MakePkg2Path;
         }
@@ -706,12 +706,20 @@ public partial class PackageCreationViewModel : BaseViewModel
             {
                 processOutput.Add(args.Data);
 
-                // Check for encryption progress messages
+                // Check for encryption progress messages (makepkg legacy)
                 var match = EncryptionProgressRegex().Match(args.Data);
                 if (match.Success && int.TryParse(match.Groups[1].Value, out int percentComplete))
                 {
                     // Map the 0-100 range to 5-95 to allow for setup and validation
                     ProgressValue = (int)(percentComplete * 0.9 + 5);
+                }
+
+                // Check for makepkg2 written progress messages
+                var msixvc2Match = Msixvc2WrittenProgressRegex().Match(args.Data);
+                if (msixvc2Match.Success && double.TryParse(msixvc2Match.Groups[1].Value, out double writtenPercent))
+                {
+                    // Map 0-100% written to 0-95%, reserving the last 5% for SubmissionValidator
+                    ProgressValue = (int)(writtenPercent * 0.95);
                 }
             }
         };
@@ -796,7 +804,7 @@ public partial class PackageCreationViewModel : BaseViewModel
         ProgressValue = 0;
         IsCreationInProgress = true;
 
-        _packingProgressPercentageProvider.IsIndeterminate = UseMsixvc2;
+        _packingProgressPercentageProvider.IsMsixvc2 = UseMsixvc2;
 
         _logger.LogInformation("Calling '{Command}'", _makePackageProcess.StartInfo.FileName + " " + _makePackageProcess.StartInfo.Arguments);
         _makePackageProcess.Start();
@@ -1020,6 +1028,9 @@ public partial class PackageCreationViewModel : BaseViewModel
 
     [GeneratedRegex(@"Encrypted (\d+) %")]
     private static partial Regex EncryptionProgressRegex();
+
+    [GeneratedRegex(@"written \((\d+(?:\.\d+)?)%\)")]
+    private static partial Regex Msixvc2WrittenProgressRegex();
 
     [GeneratedRegex(@"See the Submission Validator log file at '(?<PackagePath>.*?Validator.*?\.xml)'")]
     private static partial Regex ValidatorResultsPathRegex();

--- a/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
@@ -322,6 +322,20 @@ public partial class PackageCreationViewModel : BaseViewModel
         }
     }
 
+    private bool _useMsixvc2 = false;
+    public bool UseMsixvc2
+    {
+        get => _useMsixvc2;
+        set => SetProperty(ref _useMsixvc2, value);
+    }
+
+    private bool _isMakePkg2Available = false;
+    public bool IsMakePkg2Available
+    {
+        get => _isMakePkg2Available;
+        set => SetProperty(ref _isMakePkg2Available, value);
+    }
+
     public ICommand MakePackageCommand { get; }
     public ICommand GameDataPathDroppedCommand { get; }
     public ICommand BrowseGameDataPathCommand { get; }
@@ -370,6 +384,9 @@ public partial class PackageCreationViewModel : BaseViewModel
 
             // Future options can also be checked here to enable new features.
         }
+
+        var makePkg2Path = _pathConfigurationService.MakePkg2Path;
+        _isMakePkg2Available = !string.IsNullOrEmpty(makePkg2Path) && File.Exists(makePkg2Path);
 
         MakePackageCommand = new RelayCommand(StartMakePackageProcess, CanCreatePackage);
         GameDataPathDroppedCommand = new RelayCommand<string>(OnGameDataPathDropped);

--- a/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
@@ -672,9 +672,8 @@ public partial class PackageCreationViewModel : BaseViewModel
 
         if (UseMsixvc2)
         {
-            // Argument order matches the makepkg2 script convention: /f /pd /d /msixvc2.
-            string msixvc2CmdFormat = "pack /f \"{0}\" /pd \"{1}\" /d \"{2}\" /msixvc2 /updatesubval";
-            arguments = string.Format(msixvc2CmdFormat, MappingDataXmlPath, buildPath, GameDataPath);
+            string msixvc2CmdFormat = "pack /f \"{0}\" /pd \"{1}\" /d \"{2}\" /msixvc2 /updatesubval /validationpath \"{3}\"";
+            arguments = string.Format(msixvc2CmdFormat, MappingDataXmlPath, buildPath, GameDataPath, _settingsFolder);
             executablePath = _pathConfigurationService.MakePkg2Path;
         }
         else

--- a/src/PackageUploader.UI/ViewModel/PackagingProgressViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackagingProgressViewModel.cs
@@ -30,7 +30,7 @@ namespace PackageUploader.UI.ViewModel
             }
         }
 
-        public bool IsIndeterminate => _packingProgressPercentageProvider.IsIndeterminate;
+        public bool IsMsixvc2 => _packingProgressPercentageProvider.IsMsixvc2;
 
         public ICommand ViewLogsCommand { get; }
         public ICommand CancelCreationCommand { get; }

--- a/src/PackageUploader.UI/ViewModel/PackagingProgressViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackagingProgressViewModel.cs
@@ -30,6 +30,8 @@ namespace PackageUploader.UI.ViewModel
             }
         }
 
+        public bool IsIndeterminate => _packingProgressPercentageProvider.IsIndeterminate;
+
         public ICommand ViewLogsCommand { get; }
         public ICommand CancelCreationCommand { get; }
 


### PR DESCRIPTION
Adds a checkbox toggle ("Package as MSIXVC2 (.msixvc)") to the package creation view that switches from makepkg.exe to makepkg2.exe pack ... /msixvc2 for creating MSIXVC2 .msixvc packages. The toggle is only visible when makepkg2.exe is installed.

Changes include:
 - CheckBox toggle in the package output section, gated on makepkg2 availability
 - Process branching: builds makepkg2 pack arguments with /msixvc2 flag when toggled
 - Indeterminate progress bar: makepkg2 doesn't emit Encrypted X %, so the progress screen shows a marquee animation and hides the legacy step labels (Validating files / Copying and encrypting / Verifying contents)
 - Centered progress layout: remaining elements (image, heading, progress bar) center on screen in MSIXVC2 mode
 - Submission Validator parsing: added regex for makepkg2's different log path format (Submission Validator log path: <path>) so SubVal results display correctly on the finished screen