### PR TITLE
Fix README httpTimeoutMs example and improve UploadConfig diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Product: {
   },
 
   "uploadConfig": {
-    "httpTimeoutMs": 5000,
+    "httpTimeoutMs": 60000,
     "httpUploadTimeoutMs": 300000,
     "maxParallelism": 24,
     "defaultConnectionLimit": -1,

--- a/src/PackageUploader.ClientApi/Client/Xfus/Config/UploadConfig.cs
+++ b/src/PackageUploader.ClientApi/Client/Xfus/Config/UploadConfig.cs
@@ -12,6 +12,16 @@ public partial class UploadConfigValidator : IValidateOptions<UploadConfig>
 
 public class UploadConfig
 {
+    /// <summary>
+    /// Per-request timeout in milliseconds for non-upload XFUS HTTP calls
+    /// (e.g., initialize, continue, status checks).
+    /// Must be high enough to accommodate XVC initialize, which involves
+    /// multiple sequential storage calls and can take 2-6s cross-region.
+    /// A value that is too low (e.g., 5000ms) will cause intermittent
+    /// <see cref="System.Threading.Tasks.TaskCanceledException"/> failures
+    /// for clients in distant regions. Default is 300000ms (5 minutes).
+    /// The README example recommends 60000ms (60s) as a reasonable override.
+    /// </summary>
     [Required]
     public int HttpTimeoutMs { get; set; } = 300000;
 

--- a/src/PackageUploader.ClientApi/Client/Xfus/Uploader/XfusUploader.cs
+++ b/src/PackageUploader.ClientApi/Client/Xfus/Uploader/XfusUploader.cs
@@ -29,6 +29,18 @@ internal class XfusUploader : IXfusUploader
         _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _uploadConfig = uploadConfig?.Value ?? throw new ArgumentNullException(nameof(uploadConfig));
+
+        _logger.LogInformation(
+            "UploadConfig: HttpTimeoutMs={HttpTimeoutMs}, HttpUploadTimeoutMs={HttpUploadTimeoutMs}, " +
+            "MaxParallelism={MaxParallelism}, DefaultConnectionLimit={DefaultConnectionLimit}, " +
+            "Expect100Continue={Expect100Continue}, UseNagleAlgorithm={UseNagleAlgorithm}, RetryCount={RetryCount}",
+            _uploadConfig.HttpTimeoutMs,
+            _uploadConfig.HttpUploadTimeoutMs,
+            _uploadConfig.MaxParallelism,
+            _uploadConfig.DefaultConnectionLimit,
+            _uploadConfig.Expect100Continue,
+            _uploadConfig.UseNagleAlgorithm,
+            _uploadConfig.RetryCount);
     }
 
     public Task UploadFileToXfusAsync(FileInfo uploadFile, XfusUploadInfo xfusUploadInfo, bool deltaUpload, CancellationToken ct)

--- a/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
@@ -322,6 +322,20 @@ public partial class PackageCreationViewModel : BaseViewModel
         }
     }
 
+    private bool _useMsixvc2 = false;
+    public bool UseMsixvc2
+    {
+        get => _useMsixvc2;
+        set => SetProperty(ref _useMsixvc2, value);
+    }
+
+    private bool _isMakePkg2Available = false;
+    public bool IsMakePkg2Available
+    {
+        get => _isMakePkg2Available;
+        set => SetProperty(ref _isMakePkg2Available, value);
+    }
+
     public ICommand MakePackageCommand { get; }
     public ICommand GameDataPathDroppedCommand { get; }
     public ICommand BrowseGameDataPathCommand { get; }
@@ -370,6 +384,9 @@ public partial class PackageCreationViewModel : BaseViewModel
 
             // Future options can also be checked here to enable new features.
         }
+
+        var makePkg2Path = _pathConfigurationService.MakePkg2Path;
+        _isMakePkg2Available = !string.IsNullOrEmpty(makePkg2Path) && File.Exists(makePkg2Path);
 
         MakePackageCommand = new RelayCommand(StartMakePackageProcess, CanCreatePackage);
         GameDataPathDroppedCommand = new RelayCommand<string>(OnGameDataPathDropped);

--- a/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
@@ -322,20 +322,6 @@ public partial class PackageCreationViewModel : BaseViewModel
         }
     }
 
-    private bool _useMsixvc2 = false;
-    public bool UseMsixvc2
-    {
-        get => _useMsixvc2;
-        set => SetProperty(ref _useMsixvc2, value);
-    }
-
-    private bool _isMakePkg2Available = false;
-    public bool IsMakePkg2Available
-    {
-        get => _isMakePkg2Available;
-        set => SetProperty(ref _isMakePkg2Available, value);
-    }
-
     public ICommand MakePackageCommand { get; }
     public ICommand GameDataPathDroppedCommand { get; }
     public ICommand BrowseGameDataPathCommand { get; }
@@ -384,9 +370,6 @@ public partial class PackageCreationViewModel : BaseViewModel
 
             // Future options can also be checked here to enable new features.
         }
-
-        var makePkg2Path = _pathConfigurationService.MakePkg2Path;
-        _isMakePkg2Available = !string.IsNullOrEmpty(makePkg2Path) && File.Exists(makePkg2Path);
 
         MakePackageCommand = new RelayCommand(StartMakePackageProcess, CanCreatePackage);
         GameDataPathDroppedCommand = new RelayCommand<string>(OnGameDataPathDropped);


### PR DESCRIPTION
Fixes an issue where customers copying the README's example httpTimeoutMs: 5000 (5s) experience intermittent TaskCanceledException failures, because XVC initialize involves multiple sequential storage calls that can take 2-6s
cross-region.

Resolves ICM 784025976 (Forza Horizon 6 / Turn 10 automated uploads failing from UK/EU clients).