### PR TITLE
Fix pipeline: pin exact SDK version and add PR trigger

### DIFF
--- a/.azurePipelines/build-pipeline.yml
+++ b/.azurePipelines/build-pipeline.yml
@@ -1,5 +1,10 @@
 trigger: none
 
+pr:
+  branches:
+    include:
+      - main
+
 parameters:
   - name: Version
     default: '1.0.0'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,10 +73,10 @@ jobs:
 
     - uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.0.x'
+        global-json-file: global.json
 
     - name: Restore dependencies
-      run: dotnet restore src/PackageUploader.sln
+      run: dotnet restore src/PackageUploader.sln --locked-mode
 
     - name: Build solution
       run: dotnet build src/PackageUploader.sln --configuration Release --no-restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,9 +19,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 10.0.x
+        global-json-file: global.json
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore --locked-mode
       working-directory: ./src
     - name: Build
       run: dotnet build --no-restore

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
     "sdk": {
         "version": "10.0.203",
-        "rollForward": "latestPatch"
+        "rollForward": "disable"
     },
     "test": {
         "runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
## Problem
The CI build has been failing because `global.json` used `rollForward: latestPatch`, allowing the CI agent to install a newer SDK patch than the one used to generate lock files. The newer SDK ships different implicit package versions, breaking `--locked-mode` NuGet restore.

## Changes
- **`global.json`**: Changed `rollForward` from `latestPatch` to `disable` to ensure CI uses the exact SDK version the lock files were generated with.
- **`build-pipeline.yml`**: Added `pr` trigger for `main` branch.