### PR TITLE
[XGPM] Fix MSIXVC2 back button navigation on legacy upload path & SubmissionValidator DLL load failure

### DIFF
--- a/src/PackageUploader.UI/Model/PackageModel.cs
+++ b/src/PackageUploader.UI/Model/PackageModel.cs
@@ -27,4 +27,5 @@ public class PackageModel
     public string FolderSize { get; set; } = string.Empty;
     public string UploadArguments { get; set; } = string.Empty;
     public string MakePkg2Path { get; set; } = string.Empty;
+    public Type? UploadOriginPage { get; set; } = null;
 }

--- a/src/PackageUploader.UI/ViewModel/Msixvc2UploadViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/Msixvc2UploadViewModel.cs
@@ -616,6 +616,7 @@ public partial class Msixvc2UploadViewModel : BaseViewModel
         _packageModelProvider.Package.FolderSize = EstimatedFolderSize;
         _packageModelProvider.Package.UploadArguments = uploadArgs;
         _packageModelProvider.Package.MakePkg2Path = makePkg2Path;
+        _packageModelProvider.Package.UploadOriginPage = typeof(Msixvc2UploadView);
         if (branchOrFlight != null)
         {
             _packageModelProvider.Package.BranchId = branchOrFlight.CurrentDraftInstanceId;

--- a/src/PackageUploader.UI/ViewModel/Msixvc2UploadingViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/Msixvc2UploadingViewModel.cs
@@ -293,7 +293,7 @@ public partial class Msixvc2UploadingViewModel : BaseViewModel
 
         System.Windows.Application.Current.Dispatcher.Invoke(() =>
         {
-            _windowService.NavigateTo(typeof(Msixvc2UploadView));
+            _windowService.NavigateTo(_packageModelProvider.Package.UploadOriginPage ?? typeof(Msixvc2UploadView));
         });
     }
 
@@ -346,7 +346,7 @@ public partial class Msixvc2UploadingViewModel : BaseViewModel
     {
         _errorModelProvider.Error.MainMessage = title;
         _errorModelProvider.Error.DetailMessage = detail;
-        _errorModelProvider.Error.OriginPage = typeof(Msixvc2UploadView);
+        _errorModelProvider.Error.OriginPage = _packageModelProvider.Package.UploadOriginPage ?? typeof(Msixvc2UploadView);
         _errorModelProvider.Error.LogsPath = _lastLogFilePath;
 
         System.Windows.Application.Current.Dispatcher.Invoke(() =>

--- a/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
@@ -672,6 +672,8 @@ public partial class PackageCreationViewModel : BaseViewModel
 
         if (UseMsixvc2)
         {
+            CopyXsapiDllToSettingsFolder(_settingsFolder);
+
             string msixvc2CmdFormat = "pack /f \"{0}\" /pd \"{1}\" /d \"{2}\" /msixvc2 /updatesubval /validationpath \"{3}\"";
             arguments = string.Format(msixvc2CmdFormat, MappingDataXmlPath, buildPath, GameDataPath, _settingsFolder);
             executablePath = _pathConfigurationService.MakePkg2Path;
@@ -898,6 +900,40 @@ public partial class PackageCreationViewModel : BaseViewModel
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Copies XSAPI.dll from the GDK bin folder to the settings folder if it exists.
+    /// SubmissionValidator.dll has a native dependency on XSAPI.dll, and when makepkg2 downloads
+    /// a fresh validator via /updatesubval, XSAPI.dll must be in the same directory for it to load.
+    /// </summary>
+    private void CopyXsapiDllToSettingsFolder(string settingsFolder)
+    {
+        try
+        {
+            string? gdkBinDir = Path.GetDirectoryName(_pathConfigurationService.BaseSubValPath);
+            if (string.IsNullOrEmpty(gdkBinDir))
+            {
+                return;
+            }
+
+            string sourceXsapi = Path.Combine(gdkBinDir, "xsapi.dll");
+            if (!File.Exists(sourceXsapi))
+            {
+                return;
+            }
+
+            string destXsapi = Path.Combine(settingsFolder, "xsapi.dll");
+            if (!File.Exists(destXsapi))
+            {
+                File.Copy(sourceXsapi, destXsapi, overwrite: false);
+                _logger.LogInformation("Copied xsapi.dll to settings folder for SubmissionValidator dependency.");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Failed to copy xsapi.dll to settings folder: {message}", ex.Message);
+        }
     }
 
     private async Task GenerateMappingFile(string tempBuildPath)

--- a/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
@@ -672,6 +672,7 @@ public partial class PackageCreationViewModel : BaseViewModel
 
         if (UseMsixvc2)
         {
+            // According to the SubmissionValidator development team, an upcoming version will no longer have this dependency and this workaround will be removable
             CopyXsapiDllToSettingsFolder(_settingsFolder);
 
             string msixvc2CmdFormat = "pack /f \"{0}\" /pd \"{1}\" /d \"{2}\" /msixvc2 /updatesubval /validationpath \"{3}\"";

--- a/src/PackageUploader.UI/ViewModel/PackageUploadViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackageUploadViewModel.cs
@@ -1131,6 +1131,7 @@ public partial class PackageUploadViewModel : BaseViewModel
         Package.FolderSize = PackageSize;
         Package.UploadArguments = uploadArgs;
         Package.MakePkg2Path = makePkg2Path;
+        Package.UploadOriginPage = typeof(PackageUploadView);
         if (branchOrFlight != null)
         {
             Package.BranchId = branchOrFlight.CurrentDraftInstanceId;


### PR DESCRIPTION
Fixes two issues with MSIXVC2 packaging in Xbox Game Package Manager:
 
 1. Back Button Navigation Bug
 
When uploading an MSIXVC2 package via the legacy Upload a Package path, the error screen's "Go Back" button incorrectly navigated to Msixvc2UploadView instead of back to PackageUploadView where the user started.
 
Fix: Added UploadOriginPage property to PackageModel. Both entry points now set this before navigating to the uploading screen. Msixvc2UploadingViewModel reads it for cancel/error navigation.
 
 2. SubmissionValidator.dll Load Failure
 
When packaging with MSIXVC2 toggle, makepkg2's /updatesubval downloads SubmissionValidator.dll but it fails to load because XSAPI.dll isn't co-located.
 
Fix: Added CopyXsapiDllToSettingsFolder() that pre-copies xsapi.dll from the GDK bin directory before invoking makepkg2.