### PR TITLE
[XGPM] Remove XSAPI.dll dependency workaround

### DIFF
--- a/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
+++ b/src/PackageUploader.UI/ViewModel/PackageCreationViewModel.cs
@@ -672,9 +672,6 @@ public partial class PackageCreationViewModel : BaseViewModel
 
         if (UseMsixvc2)
         {
-            // According to the SubmissionValidator development team, an upcoming version will no longer have this dependency and this workaround will be removable
-            CopyXsapiDllToSettingsFolder(_settingsFolder);
-
             string msixvc2CmdFormat = "pack /f \"{0}\" /pd \"{1}\" /d \"{2}\" /msixvc2 /updatesubval /validationpath \"{3}\"";
             arguments = string.Format(msixvc2CmdFormat, MappingDataXmlPath, buildPath, GameDataPath, _settingsFolder);
             executablePath = _pathConfigurationService.MakePkg2Path;
@@ -901,40 +898,6 @@ public partial class PackageCreationViewModel : BaseViewModel
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// Copies XSAPI.dll from the GDK bin folder to the settings folder if it exists.
-    /// SubmissionValidator.dll has a native dependency on XSAPI.dll, and when makepkg2 downloads
-    /// a fresh validator via /updatesubval, XSAPI.dll must be in the same directory for it to load.
-    /// </summary>
-    private void CopyXsapiDllToSettingsFolder(string settingsFolder)
-    {
-        try
-        {
-            string? gdkBinDir = Path.GetDirectoryName(_pathConfigurationService.BaseSubValPath);
-            if (string.IsNullOrEmpty(gdkBinDir))
-            {
-                return;
-            }
-
-            string sourceXsapi = Path.Combine(gdkBinDir, "xsapi.dll");
-            if (!File.Exists(sourceXsapi))
-            {
-                return;
-            }
-
-            string destXsapi = Path.Combine(settingsFolder, "xsapi.dll");
-            if (!File.Exists(destXsapi))
-            {
-                File.Copy(sourceXsapi, destXsapi, overwrite: false);
-                _logger.LogInformation("Copied xsapi.dll to settings folder for SubmissionValidator dependency.");
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning("Failed to copy xsapi.dll to settings folder: {message}", ex.Message);
-        }
     }
 
     private async Task GenerateMappingFile(string tempBuildPath)


### PR DESCRIPTION
## Context

SubmissionValidator was recently refactored and no longer depends on XSAPI.dll. This removes the temporary XGPM workaround that copied XSAPI.dll into the settings folder before MSIXVC2 packaging, while preserving the existing validator update flow.

## Validation

- Clean PackageUploader.UI build
- Full automated test suite
- Manual MSIXVC2 package creation and upload