### PR TITLE
Document the exact .NET SDK version required to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,11 @@ Alternately, the executables (both the GUI and CMD tools) are also available fro
 
 Furthermore, you can also build it.
 
-1. [Download the .NET 10 SDK](https://dotnet.microsoft.com/en-us/download) or the latest version.
+1. [Download the .NET SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0), specifically version **10.0.203**.
+
+   This repository pins the SDK in [`global.json`](global.json) with `"rollForward": "disable"`, so the build requires that exact version and will not fall back to a newer SDK. If a different SDK is installed, `dotnet build` fails with `Install the [10.0.203] .NET SDK or update global.json to match an installed SDK`.
+
+   The pin is deliberate. All projects restore with [NuGet lock files](https://learn.microsoft.com/nuget/consume-packages/package-references-in-project-files#locking-dependencies), and different SDK versions resolve different transitive package versions, which would otherwise cause spurious `packages.lock.json` changes to appear in unrelated pull requests. Installing 10.0.203 alongside your existing SDKs is safe; it does not replace them.
 2. Open PowerShell, and then browse to the folder where you downloaded Package Uploader.
 3. Browse to the `src` folder, and then run `./publish.win-x64.ps1`.
 4. When it's built, PackageUploader.exe is in the `src\PackageUploader.Application\bin\release\win-x64\publish` directory.


### PR DESCRIPTION
Fixes a documentation bug that makes the build instructions unfollowable.

## Problem

`README.md` told contributors:

> 1. [Download the .NET 10 SDK](https://dotnet.microsoft.com/en-us/download) or the latest version.

But `global.json` pins the SDK exactly:

```json
"sdk": { "version": "10.0.203", "rollForward": "disable" }
```

`rollForward: disable` permits no roll-forward at all — not even a patch. So `or the latest version` is precisely what the repository forbids. A contributor who follows the README installs a newer SDK and every `dotnet build`, `dotnet test` and `dotnet restore` in the repo fails with:

```
Install the [10.0.203] .NET SDK or update [global.json] to match an installed SDK.
```

CI never hits this, which is why it went unnoticed: Azure Pipelines uses `UseDotNet@2` with `useGlobalJson: true` and the GitHub Actions workflow uses `actions/setup-dotnet@v5` with `global-json-file: global.json`. Both *install* the pinned SDK on demand. Only humans are affected.

## Why the pin is kept rather than loosened

Loosening to `rollForward: latestFeature` would fix the symptom but was rejected after testing. Every project sets `RestorePackagesWithLockFile`, and different SDK versions resolve different transitive package versions. Restoring this repo under 10.0.303 rewrites all four `packages.lock.json` files (`Microsoft.NET.ILLink.Tasks` 10.0.7 → 10.0.11). A looser pin would let contributors on different SDKs generate conflicting lock files and leak unrelated `packages.lock.json` diffs into pull requests.

Verified after installing 10.0.203: a clean build of the solution produces **0 warnings, 0 errors** and **no lock file churn at all**. That confirms the pin is doing real work, so the fix is to document it accurately rather than weaken it.

## Change

Docs only. `README.md` now:

- names the required version, **10.0.203**, and links to the .NET 10 download page rather than the generic one
- quotes the exact error produced by the wrong SDK, so it is searchable
- explains *why* the pin exists, so the next person hitting it fixes their SDK instead of loosening `global.json`
- notes that installing 10.0.203 alongside existing SDKs is safe and non-destructive

No build, project, or dependency changes. `global.json` is intentionally untouched.
